### PR TITLE
Suggested improvement for client-side generated IDs (eg UUIDs)

### DIFF
--- a/dialects/base/model.js
+++ b/dialects/base/model.js
@@ -28,6 +28,9 @@ var ModelBase = function(attributes, options) {
     _.extend(this, _.pick(options, modelProps));
     if (options.parse) attrs = this.parse(attrs, options) || {};
   }
+  if (this.newId) {
+    this._newId = this.newId();
+  }
   this.set(attrs, options);
   this.initialize.apply(this, arguments);
 };

--- a/dialects/sql/model.js
+++ b/dialects/sql/model.js
@@ -177,6 +177,12 @@ exports.Model = ModelBase.extend({
       ])
       .bind(this)
       .then(function() {
+        // If an ID has been explicitly defined, set it now
+        if(isNew && this._newId)
+        {
+            this.set(this.idAttribute, this._newId);
+        }
+
         return sync[options.method](method === 'update' && options.patch ? attrs : this.attributes);
       })
       .then(function(resp) {

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -1,3 +1,4 @@
+var uuid = require('node-uuid');
 
 // All Models & Collections Used in the Tests
 // (sort of mimics a simple multi-site blogging engine)
@@ -27,6 +28,9 @@ module.exports = function(Bookshelf) {
 
   var Uuid = Bookshelf.Model.extend({
     idAttribute: 'uuid',
+    generateId: function(){
+      return uuid.v4();
+    },
     tableName: 'uuid_test'
   });
 

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -28,7 +28,12 @@ module.exports = function(Bookshelf) {
 
   var Uuid = Bookshelf.Model.extend({
     idAttribute: 'uuid',
-    generateId: function(){
+    tableName: 'uuid_test'
+  });
+
+  var Uuid2 = Bookshelf.Model.extend({
+    idAttribute: 'uuid',
+    newId: function(){
       return uuid.v4();
     },
     tableName: 'uuid_test'
@@ -267,7 +272,8 @@ module.exports = function(Bookshelf) {
       Settings: Settings,
       Instance: Instance,
       Hostname: Hostname,
-      Uuid: Uuid
+      Uuid: Uuid,
+      Uuid2: Uuid2
     },
     Collections: {
       Sites: Sites,

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -429,6 +429,20 @@ module.exports = function(Bookshelf) {
         });
       });
 
+      it('Allows autogenerating a uuid using generateId', function() {
+        var SubSite = Models.Uuid.extend();
+        var subsite = new SubSite({name: 'testing'});
+        var uuidval = subsite.id;
+        return subsite.save().then(function(model) {
+          expect(model.id).to.equal(uuidval);
+          expect(model.get('name')).to.equal('testing');
+        }).then(function() {
+          return new SubSite({uuid: uuidval}).fetch();
+        }).then(function(model) {
+          expect(model.get('name')).to.equal('testing');
+        });
+      });
+
     });
 
     describe('destroy', function() {
@@ -645,13 +659,25 @@ module.exports = function(Bookshelf) {
     });
 
     describe('isNew', function() {
+      var Instance = Models.Instance;
 
-      it('uses the idAttribute to determine if the model isNew', function(){
-        var model = new Bookshelf.Model();
-        model.id = 1;
-        equal(model.isNew(), false);
-        model.set('id', null);
-        equal(model.isNew(), true);
+      it('returns true when a new model is instantiated', function(){
+        var instance = new Instance();
+        equal(instance.isNew(), true);
+      });
+
+      it('returns false after a new model is saved', function(ok){
+        var instance = new Instance();
+        equal(instance.isNew(), true);
+        instance.save().then(function(instance){
+            equal(instance.isNew(), false);
+            ok();
+        }).catch(ok);
+      });
+
+      it('returns false when an id is explicitly set', function(){
+        var instance = new Instance({id: '56'});
+        equal(instance.isNew(), false);
       });
 
     });

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -429,10 +429,10 @@ module.exports = function(Bookshelf) {
         });
       });
 
-      it('Allows autogenerating a uuid using generateId', function() {
-        var SubSite = Models.Uuid.extend();
+      it('Allows autogenerating a uuid using newId', function() {
+        var SubSite = Models.Uuid2.extend();
         var subsite = new SubSite({name: 'testing'});
-        var uuidval = subsite.id;
+        var uuidval = subsite._newId;
         return subsite.save().then(function(model) {
           expect(model.id).to.equal(uuidval);
           expect(model.get('name')).to.equal('testing');


### PR DESCRIPTION
This change simplifies situations where the ID is generated by the client rather than by the database. 

Current solutions hook into the 'saving' event to generate an ID, which means that the generated ID cannot be retrieved by the client before the model is saved. This removes one of the advantages of using UUIDs - if you know the ID before saving you can fire off multiple save queries for related models in parallel.

This pull request allows the ID generation function to be specified on the model definition - for example:
```javascript
var Uuid = Bookshelf.Model.extend({
  idAttribute: 'uuid',
  tableName: 'uuid_test',
  generateId: function(){
    return uuid.v4();
  },
});
```

**This change overrides the backbone.js isNew function**. This doesn't break any existing tests - except a single test: "uses the idAttribute to determine if the model isNew". This test was replaced with three others which better capture the expected behaviour of isNew.