### PR TITLE
Add support to update/delete composite keys models

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -19,6 +19,19 @@ var Sync = function(syncing, options) {
 
 _.extend(Sync.prototype, {
 
+  // Add where conditions to identify the object.
+  addIdAttributes: function(syncing, query) {
+    if (syncing.id != null) {
+      if(_.isArray(syncing.idAttribute)) {
+        _.each(syncing.idAttribute, function(id) {
+            query.where(id, syncing.id[id]);
+        });
+      } else {
+        query.where(syncing.idAttribute, syncing.id);
+      }
+    }
+  },
+
   // Prefix all keys of the passed in object with the
   // current table name
   prefixFields: function(fields) {
@@ -80,7 +93,7 @@ _.extend(Sync.prototype, {
   // Issues an `update` command on the query - only used by models.
   update: Promise.method(function(attrs) {
     var syncing = this.syncing, query = this.query;
-    if (syncing.id != null) query.where(syncing.idAttribute, syncing.id);
+    this.addIdAttributes(syncing, query);
     if (_.where(query._statements, {grouping: 'where'}).length === 0) {
       throw new Error('A model cannot be updated without a "where" clause or an idAttribute.');
     }
@@ -90,7 +103,7 @@ _.extend(Sync.prototype, {
   // Issues a `delete` command on the query.
   del: Promise.method(function() {
     var query = this.query, syncing = this.syncing;
-    if (syncing.id != null) query.where(syncing.idAttribute, syncing.id);
+    this.addIdAttributes(syncing, query);
     if (_.where(query._statements, {grouping: 'where'}).length === 0) {
       throw new Error('A model cannot be destroyed without a "where" clause or an idAttribute.');
     }


### PR DESCRIPTION
@bendrucker Regaring #420.

As @cbollerud said, we could be missing something.

This update to the sync code allows to simply

```js
entity.save(data)
```

on an instance of 

```js
// Simplified/dummy model.
bookshelf.Model.extend({
  idAttribute: ['fooId', 'barId'],
  tableName: 'foobar'
}
```

Whitout `Error: column "0" does not exist`.


Note: This code could be buggy and is not tested yet.