### PR TITLE
Allow {require: true} to be passed to `model.destroy`.

### DIFF
--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -5,6 +5,7 @@ var Backbone = require('backbone');
 
 var Events   = require('./events');
 var Promise  = require('./promise');
+var Errors   = require('../errors');
 
 // A list of properties that are omitted from the `Backbone.Model.prototype`, to create
 // a generic model base.
@@ -176,6 +177,9 @@ _.extend(ModelBase.prototype, _.omit(Backbone.Model.prototype, modelOmitted), Ev
     }).then(function() {
       return sync.del();
     }).then(function(resp) {
+      if (options.require && !resp) {
+          throw new Errors.NoRowsDeletedError('EmptyResponse');
+      }
       this.clear();
       return this.triggerThen('destroyed', this, resp, options);
     }).then(this._reset);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -10,6 +10,9 @@ module.exports = {
   EmptyError: createError('EmptyError'),
 
   // Thrown when an update affects no rows and {require: true} is passed in model.save.
-  NoRowsUpdatedError: createError('NoRowsUpdatedError')
+  NoRowsUpdatedError: createError('NoRowsUpdatedError'),
+
+  // Thrown when a delete affects no rows and {require: true} is passed in model.destroy.
+  NoRowsDeletedError: createError('NoRowsDeletedError')
 
 };

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -528,6 +528,14 @@ module.exports = function(bookshelf) {
         return m.destroy();
       });
 
+      it('will throw an error when trying to destroy a non-existent object with {require: true}', function() {
+        var m = new Site({id: 1337})
+        return m.destroy({require: true}).then(function() {
+        }).then(function() {
+          throw Error('No exception thrown');
+        }).catch(bookshelf.NoRowsDeletedError, _.noop);
+      });
+
     });
 
     describe('resetQuery', function() {


### PR DESCRIPTION
Closes tgriesser/bookshelf#617