### PR TITLE
`.belongsToMany().though()` Pivot/Join Model Lifecycle Events #578

### DIFF
--- a/lib/relation.js
+++ b/lib/relation.js
@@ -426,11 +426,44 @@ var pivotHelpers = {
     return Promise.all(pending).yield(this);
   }),
 
-  // Handles setting the appropriate constraints and shelling out
+  // Handles preparing the appropriate constraints and then delegates
+  // the database interaction to _processPlainPivot for non-.through()
+  // pivot definitions, or _processModelPivot for .through() models.
+  // Returns a promise.
+  _processPivot: Promise.method(function(method, item, options) {
+    var relatedData = this.relatedData
+      , args        = Array.prototype.slice.call(arguments)
+      , fks         = {}
+      , data        = {};
+
+    fks[relatedData.key('foreignKey')] = relatedData.parentFk;
+
+    // If the item is an object, it's either a model
+    // that we're looking to attach to this model, or
+    // a hash of attributes to set in the relation.
+    if (_.isObject(item)) {
+      if (item instanceof ModelBase) {
+        fks[relatedData.key('otherKey')] = item.id;
+      } else if (method !== 'update') {
+        _.extend(data, item);
+      }
+    } else if (item) {
+      fks[relatedData.key('otherKey')] = item;
+    }
+
+    args.push(_.extend(data, fks), fks);
+
+    if (this.relatedData.throughTarget) {
+      return this._processModelPivot.apply(this, args);
+    }
+
+    return this._processPlainPivot.apply(this, args);
+  }),
+
+  // Applies constraints to the knex builder and handles shelling out
   // to either the `insert` or `delete` call for the current model,
   // returning a promise.
-  _processPivot: Promise.method(function(method, item, options) {
-    var data = {};
+  _processPlainPivot: Promise.method(function(method, item, options, data, fks) {
     var relatedData = this.relatedData;
 
     // Grab the `knex` query builder for the current model, and
@@ -440,25 +473,11 @@ var pivotHelpers = {
       Helpers.query.call(null, {_knex: builder}, [options.query]);
     }
 
-    data[relatedData.key('foreignKey')] = relatedData.parentFk;
-
-    // If the item is an object, it's either a model
-    // that we're looking to attach to this model, or
-    // a hash of attributes to set in the relation.
-    if (_.isObject(item)) {
-      if (item instanceof ModelBase) {
-        data[relatedData.key('otherKey')] = item.id;
-      } else if (method !== 'update') {
-        _.extend(data, item);
-      }
-    } else if (item) {
-      data[relatedData.key('otherKey')] = item;
-    }
-
     if (options) {
       if (options.transacting) builder.transacting(options.transacting);
       if (options.debug) builder.debug();
     }
+
     var collection = this;
     if (method === 'delete') {
       return builder.where(data).del().then(function() {
@@ -480,6 +499,33 @@ var pivotHelpers = {
 
     return builder.insert(data).then(function() {
       collection.add(item);
+    });
+  }),
+
+  // Loads or prepares a pivot model based on the constraints and deals with
+  // pivot model changes by calling the appropriate Bookshelf Model API
+  // methods. Returns a promise.
+  _processModelPivot: Promise.method(function(method, item, options, data, fks) {
+    var relatedData = this.relatedData
+      , JoinModel   = relatedData.throughTarget
+      , instance    = new JoinModel
+      , parser      = instance.parse;
+
+    fks = parser(fks);
+    data = parser(data);
+
+    if (method === 'insert') {
+      return instance.set(data).save(null, options);
+    }
+
+    return instance.set(fks).fetch({
+      require: true
+    }).then(function (instance) {
+      if (method === 'delete') {
+        return instance.destroy(options);
+      }
+
+      return instance.save(item, options);
     });
   })
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -44,16 +44,13 @@ _.extend(Sync.prototype, {
   // the promise is resolved. Any `success` handler passed in the
   // options will be called - used by both models & collections.
   select: Promise.method(function() {
-    var columns, sync = this,
-      options = this.options, relatedData = this.syncing.relatedData;
-    var knex = this.query;
-    var columnsInQuery = _.some(knex._statements, {grouping:'columns'});
+    var knex           = this.query
+      , options        = this.options
+      , relatedData    = this.syncing.relatedData
+      , columnsInQuery = _.some(knex._statements, {grouping:'columns'})
+      , columns;
 
-    // Inject all appropriate select costraints dealing with the relation
-    // into the `knex` query builder for the current instance.
-    if (relatedData) {
-      relatedData.selectConstraints(knex, options);
-    } else {
+    if (!relatedData) {
       columns = options.columns;
       // Call the function, if one exists, to constrain the eager loaded query.
       if (options._beforeFn) options._beforeFn.call(knex, knex);
@@ -73,8 +70,26 @@ _.extend(Sync.prototype, {
     // access in the `fetching` event handlers.
     options.query = knex;
 
-    // Trigger a `fetching` event on the model, and then select the appropriate columns.
-    return Promise.bind(this).then(function() {
+    return Promise.bind(this).then(function () {
+      var fks = {}
+        , through;
+
+      // Inject all appropriate select costraints dealing with the relation
+      // into the `knex` query builder for the current instance.
+      if (relatedData) {
+        if (relatedData.throughTarget) {
+          fks[relatedData.key('foreignKey')] = relatedData.parentFk;
+          through = new relatedData.throughTarget(fks);
+          return through.triggerThen('fetching', through, relatedData.pivotColumns, options)
+            .then(function () {
+              relatedData.pivotColumns = through.parse(relatedData.pivotColumns);
+              relatedData.selectConstraints(knex, options);
+            });
+        } else {
+          relatedData.selectConstraints(knex, options);
+        }
+      }
+    }).then(function () {
       return this.syncing.triggerThen('fetching', this.syncing, columns, options);
     }).then(function() {
       return knex.select(columns);

--- a/test/integration/helpers/migration.js
+++ b/test/integration/helpers/migration.js
@@ -7,7 +7,8 @@ var drops = [
   'blogs', 'posts', 'tags', 'posts_tags', 'comments',
   'users', 'roles', 'photos', 'users_roles', 'info',
   'Customer', 'Settings', 'hostnames', 'instances', 'uuid_test',
-  'parsed_users', 'tokens', 'thumbnails'
+  'parsed_users', 'tokens', 'thumbnails',
+  'lefts', 'rights', 'lefts_rights'
 ];
 
 module.exports = function(Bookshelf) {
@@ -144,6 +145,19 @@ module.exports = function(Bookshelf) {
       table.increments();
       table.string('parsed_user_id');
       table.string('token');
+    })
+    // 
+    .createTable('lefts', function(table) {
+      table.increments();
+    })
+    .createTable('rights', function(table) {
+      table.increments();
+    })
+    .createTable('lefts_rights', function(table) {
+      table.increments();
+      table.string('parsed_name');
+      table.integer('left_id').notNullable();
+      table.integer('right_id').notNullable();
     });
 
   });

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -287,6 +287,49 @@ module.exports = function(Bookshelf) {
     tableName: 'parsed_users',
   });
 
+
+  /**
+   * Issue #578 - lifecycle events on pivot model for belongsToMany().through()
+   *
+   * Here we bootstrap some models involved in a .belongsToMany().through()
+   * relationship. The models are overridden with actual relationship methods
+   * e.g. `lefts: function () { return this.belongsToMany(LeftModel).through(JoinModel) }`
+   * within the tests to ensure the appropriate lifecycle events are being
+   * triggered.
+   */
+
+  var LeftModel = Bookshelf.Model.extend({
+    tableName: 'lefts'
+  });
+
+  var RightModel = Bookshelf.Model.extend({
+    tableName: 'rights'
+  });
+
+  var JoinModel = Bookshelf.Model.extend({
+    tableName: 'lefts_rights',
+    defaults: { parsedName: '' },
+    format: function (attrs) {
+      return _.reduce(attrs, function(memo, val, key) {
+        memo[_.str.underscored(key)] = val;
+        return memo;
+      }, {});
+    },
+    parse: function (attrs) {
+      return _.reduce(attrs, function(memo, val, key) {
+        memo[_.str.camelize(key)] = val;
+        return memo;
+      }, {});
+    },
+    lefts: function() {
+      return this.belongsTo(LeftModel);
+    },
+    rights: function() {
+      return this.belongsTo(RightModel);
+    }
+  });
+
+
   return {
     Models: {
       Site: Site,
@@ -312,7 +355,10 @@ module.exports = function(Bookshelf) {
       Settings: Settings,
       Instance: Instance,
       Hostname: Hostname,
-      Uuid: Uuid
+      Uuid: Uuid,
+      LeftModel: LeftModel,
+      RightModel: RightModel,
+      JoinModel: JoinModel
     }
   };
 

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -42,6 +42,10 @@ module.exports = function(Bookshelf) {
     var UserParsed = Models.UserParsed;
     var UserTokenParsed = Models.UserTokenParsed;
 
+    var LeftModel   = Models.LeftModel;
+    var RightModel  = Models.RightModel;
+    var JoinModel   = Models.JoinModel;
+
     describe('Bookshelf Relations', function() {
 
       describe('Standard Relations - Models', function() {
@@ -858,6 +862,86 @@ module.exports = function(Bookshelf) {
         });
       });
 
+    });
+
+
+    describe('Issue #578 - lifecycle events on pivot model for belongsToMany().through()', function () {
+
+      // Overrides the `initialize` method on the JoinModel to throw an Error
+      // when the current lifecycleEvent is triggered. Additionally overrides
+      // the Left/Right models `.belongsToMany().through()` configuration with
+      // the overridden JoinModel.
+      function initializeModelsForLifecycleEvent(lifecycleEvent) {
+        JoinModel = JoinModel.extend({
+          initialize: (function (v) {
+            return function () {
+              this.on(lifecycleEvent, function () {
+                throw new Error('`' + lifecycleEvent + '` triggered on JoinModel()');
+              });
+            };
+          }(lifecycleEvent))
+        });
+
+        LeftModel = LeftModel.extend({
+          rights: function () {
+            return this.belongsToMany(RightModel).through(JoinModel);
+          }
+        });
+
+        RightModel = RightModel.extend({
+          lefts: function () {
+            return this.belongsToMany(LeftModel).through(JoinModel).withPivot(['parsedName']);
+          }
+        });
+      };
+
+      // First, initialize the models for the current `lifecycleEvent`, then
+      // step through the entire lifecycle of a JoinModel, returning a promise.
+      function joinModelLifecycleRoutine(lifecycleEvent) {
+        initializeModelsForLifecycleEvent(lifecycleEvent);
+        return (new LeftModel).save().then(function (left) {
+          // creating, saving, created, saved
+          return [left, left.rights().create()];
+        }).spread(function (left, right) {
+          // fetching, fetched
+          return [left, right, right.lefts().fetch()];
+        }).spread(function (left, right, lefts) {
+          // updating, updated
+          return [left, right, left.rights().updatePivot({})];
+        }).spread(function (left, right, relationship) {
+          return (new LeftModel).save().then(function (left) {
+            return [left, right, right.lefts().attach(left)];
+          });
+        }).spread(function (left, right, relationship) {
+          // destroying, destroyed
+          return left.rights().detach(right);
+        });
+      }
+
+      // For each lifecycle event that should be triggered on the JoinModel,
+      // build a test that verifies the expected Error is being thrown by the
+      // JoinModel's lifecycle event handler.
+
+      [
+        'creating',
+        'created',
+        'saving',
+        'saved',
+        'fetching',
+        'fetched',
+        'updating',
+        'updated',
+        'destroying',
+        'destroyed'
+      ].forEach(function (v) {
+        it('should trigger pivot model lifecycle event: ' + v, function () {
+          return joinModelLifecycleRoutine(v).catch(function (err) {
+            expect(err)
+              .to.be.an.instanceOf(Error)
+              .and.to.have.property('message', '`' + v + '` triggered on JoinModel()');
+          });
+        });
+      });
     });
 
   });


### PR DESCRIPTION
This pull requests adds handling for lifecycle events on through models for `.belongsToMany().though()` relationships along with relevant tests. I could use another set of eyes on this to make sure I'm handling all use cases correctly and haven't overstepped anywhere.