### PR TITLE
Null morphTo relations

### DIFF
--- a/lib/relation.js
+++ b/lib/relation.js
@@ -16,6 +16,13 @@ function BookshelfRelation() {
 }
 inherits(BookshelfRelation, RelationBase);
 
+function NullMorphToRelation() {};
+_.extend(NullMorphToRelation.prototype, {
+  fetch: function() {
+    return Promise.resolve(null);
+  }
+});
+
 _.extend(BookshelfRelation.prototype, {
 
   // Assembles the new model or collection we're creating an instance of,
@@ -34,6 +41,10 @@ _.extend(BookshelfRelation.prototype, {
       // If the parent object is eager loading, and it's a polymorphic `morphTo` relation,
       // we can't know what the target will be until the models are sorted and matched.
       if (this.type === 'morphTo' && !parent._isEager) {
+        // If association is empty, we have insufficient info for morphing to
+        // the correct target model.
+        if(_.isNull(attributes[this.key('morphKey')])) { return new NullMorphToRelation(); }
+
         this.target = Helpers.morphCandidate(this.candidates, attributes[this.key('morphKey')]);
         this.targetTableName   = _.result(this.target.prototype, 'tableName');
         this.targetIdAttribute = _.result(this.target.prototype, 'idAttribute');


### PR DESCRIPTION
TL;DR If a morphTo association is null, return a NullMorphToAssociation rather than raising when trying to lookup the target type.

Given the following association:

```javascript
var Article = bookshelf.Model.extend({
  modifiedBy: function() {
    this.morphTo('modified_by', 'Author', 'Admin');
  }
});
```

If a record has null values for `modified_by_type` and `modified_by_id`, and `article.modifiedBy()` is called, it will currently throw "The target polymorphic model was not found" because there is (understandably) insufficient information to lookup the type of the associated model.

This change allows for the developer to not have to be concerned with whether that column is set, but rather call the `modifiedBy` function reliably for both records that have this association present and those that don't. The `NullMorphToAssociation` would ideally be a duck type of the expected return value from a call to `morphTo`.

Thoughts on this? If anyone wants to go down this path, I'll find some time to add tests and ensure its integration.