### PR TITLE
Enable to use disinct NotFoundError for each model

### DIFF
--- a/bookshelf.js
+++ b/bookshelf.js
@@ -166,7 +166,7 @@ Bookshelf.initialize = function(knex) {
   };
   Collection.extend = function(protoProps, staticProps){
     this.EmptyError = createError(BookshelfCollection.EmptyError,
-      _.capitalize(protoProps.tableName) + "EmptyError");
+      _.capitalize(protoProps.tableName) + 'EmptyError');
     return require('simple-extend').apply(this, [protoProps, staticProps])
   };
 

--- a/bookshelf.js
+++ b/bookshelf.js
@@ -18,10 +18,16 @@ Bookshelf.initialize = function(knex) {
     VERSION: '0.7.9'
   };
 
-  var _          = require('lodash');
-  var inherits   = require('inherits');
-  var semver     = require('semver');
+  var _           = require('lodash');
+  var inherits    = require('inherits');
+  var semver      = require('semver');
   var createError = require('create-error');
+
+  // shim of capitalize to lodash v2.x
+  _.capitalize = _.capitalize || function capitalize(string) {
+    string = baseToString(string);
+    return string && (string.charAt(0).toUpperCase() + string.slice(1));
+  };
 
   // We've supplemented `Events` with a `triggerThen`
   // method to allow for asynchronous event handling via promises. We also

--- a/bookshelf.js
+++ b/bookshelf.js
@@ -25,7 +25,6 @@ Bookshelf.initialize = function(knex) {
 
   // shim of capitalize to lodash v2.x
   _.capitalize = _.capitalize || function capitalize(string) {
-    string = baseToString(string);
     return string && (string.charAt(0).toUpperCase() + string.slice(1));
   };
 

--- a/bookshelf.js
+++ b/bookshelf.js
@@ -161,12 +161,12 @@ Bookshelf.initialize = function(knex) {
       this[errorType] = createError(BookshelfModel[errorType],
       _.capitalize((protoProps.tableName) || '') + errorType);
     }.bind(this));
-    return require('simple-extend').apply(this, [protoProps, staticProps])
+    return require('simple-extend').apply(this, [protoProps, staticProps]);
   };
   Collection.extend = function(protoProps, staticProps){
     this.EmptyError = createError(BookshelfCollection.EmptyError,
       _.capitalize(protoProps.tableName) + 'EmptyError');
-    return require('simple-extend').apply(this, [protoProps, staticProps])
+    return require('simple-extend').apply(this, [protoProps, staticProps]);
   };
 
   return bookshelf;

--- a/bookshelf.js
+++ b/bookshelf.js
@@ -155,17 +155,20 @@ Bookshelf.initialize = function(knex) {
   });
   Model.fetchAll = function(options) { return this.forge().fetchAll(options); };
 
+  // Model.extend = require('simple-extend');
+  Collection.extend = require('simple-extend');
   Model.extend = function(protoProps, staticProps){
-    // Set per-model Error
+    if(typeof protoProps === 'undefined') protoProps = {};
+    if(typeof staticProps === 'undefined') staticProps = {};
     ['NotFoundError', 'NoRowsUpdatedError', 'NoRowsDeletedError'].forEach(function(errorType){
-      this[errorType] = createError(BookshelfModel[errorType],
+      staticProps[errorType] = createError(this[errorType],
       _.capitalize((protoProps.tableName) || '') + errorType);
-    }.bind(this));
+    }, this);
     return require('simple-extend').apply(this, [protoProps, staticProps]);
   };
   Collection.extend = function(protoProps, staticProps){
-    this.EmptyError = createError(BookshelfCollection.EmptyError,
-      _.capitalize(protoProps.tableName) + 'EmptyError');
+    if(typeof staticProps === 'undefined') staticProps = {};
+    staticProps.EmptyError = createError(this.EmptyError, 'EmptyError');
     return require('simple-extend').apply(this, [protoProps, staticProps]);
   };
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -35,7 +35,7 @@ _.extend(BookshelfCollection.prototype, {
       .bind(this)
       .tap(function(response) {
         if (!response || response.length === 0) {
-          if (options.require) throw new Errors.EmptyError('EmptyResponse');
+          if (options.require) throw new this.constructor.EmptyError('EmptyResponse');
           return Promise.reject(null);
         }
       })

--- a/lib/model.js
+++ b/lib/model.js
@@ -17,6 +17,8 @@ function BookshelfModel() {
 inherits(BookshelfModel, ModelBase);
 
 BookshelfModel.NotFoundError = Errors.NotFoundError;
+BookshelfModel.NoRowsUpdatedError = Errors.NoRowsUpdatedError
+BookshelfModel.NoRowsDeletedError = Errors.NoRowsDeletedError;
 
 _.extend(BookshelfModel.prototype, {
 
@@ -163,6 +165,7 @@ _.extend(BookshelfModel.prototype, {
   // If an error is thrown during these events, the model will not be saved.
   save: Promise.method(function(key, val, options) {
     var attrs;
+    var self = this;
 
     // Handle both `"key", value` and `{key: value}` -style arguments.
     if (key == null || typeof key === "object") {
@@ -225,7 +228,7 @@ _.extend(BookshelfModel.prototype, {
         if (method === 'insert' && this.id == null) {
           this.attributes[this.idAttribute] = this.id = resp[0];
         } else if (method === 'update' && resp === 0 && options.require) {
-          throw new Errors.NoRowsUpdatedError('EmptyResponse');
+          throw new self.constructor.NoRowsUpdatedError('EmptyResponse');
         }
 
         // In case we need to reference the `previousAttributes` for the this
@@ -246,6 +249,7 @@ _.extend(BookshelfModel.prototype, {
   // and after the model is destroyed, respectively. If an error is thrown
   // during the "destroying" event, the model will not be destroyed.
   destroy: Promise.method(function(options) {
+    var self = this;
     options = options ? _.clone(options) : {};
     var sync = this.sync(options);
     options.query = sync.query;
@@ -255,7 +259,7 @@ _.extend(BookshelfModel.prototype, {
       return sync.del();
     }).then(function(resp) {
       if (options.require && resp === 0) {
-        throw new Errors.NoRowsDeletedError('EmptyResponse');
+        throw new self.constructor.NoRowsDeletedError('EmptyResponse');
       }
       this.clear();
       return this.triggerThen('destroyed', this, resp, options);

--- a/lib/model.js
+++ b/lib/model.js
@@ -17,7 +17,7 @@ function BookshelfModel() {
 inherits(BookshelfModel, ModelBase);
 
 BookshelfModel.NotFoundError = Errors.NotFoundError;
-BookshelfModel.NoRowsUpdatedError = Errors.NoRowsUpdatedError
+BookshelfModel.NoRowsUpdatedError = Errors.NoRowsUpdatedError;
 BookshelfModel.NoRowsDeletedError = Errors.NoRowsDeletedError;
 
 _.extend(BookshelfModel.prototype, {

--- a/lib/model.js
+++ b/lib/model.js
@@ -97,7 +97,7 @@ _.extend(BookshelfModel.prototype, {
       // Jump the rest of the chain if the response doesn't exist...
       .tap(function(response) {
         if (!response || response.length === 0) {
-          if (options.require) throw new Errors.NotFoundError('EmptyResponse');
+          if (options.require) throw new this.constructor.NotFoundError('EmptyResponse');
           return Promise.reject(null);
         }
       })

--- a/lib/model.js
+++ b/lib/model.js
@@ -165,7 +165,6 @@ _.extend(BookshelfModel.prototype, {
   // If an error is thrown during these events, the model will not be saved.
   save: Promise.method(function(key, val, options) {
     var attrs;
-    var self = this;
 
     // Handle both `"key", value` and `{key: value}` -style arguments.
     if (key == null || typeof key === "object") {
@@ -228,7 +227,7 @@ _.extend(BookshelfModel.prototype, {
         if (method === 'insert' && this.id == null) {
           this.attributes[this.idAttribute] = this.id = resp[0];
         } else if (method === 'update' && resp === 0 && options.require) {
-          throw new self.constructor.NoRowsUpdatedError('EmptyResponse');
+          throw new this.constructor.NoRowsUpdatedError('EmptyResponse');
         }
 
         // In case we need to reference the `previousAttributes` for the this
@@ -249,7 +248,6 @@ _.extend(BookshelfModel.prototype, {
   // and after the model is destroyed, respectively. If an error is thrown
   // during the "destroying" event, the model will not be destroyed.
   destroy: Promise.method(function(options) {
-    var self = this;
     options = options ? _.clone(options) : {};
     var sync = this.sync(options);
     options.query = sync.query;
@@ -259,7 +257,7 @@ _.extend(BookshelfModel.prototype, {
       return sync.del();
     }).then(function(resp) {
       if (options.require && resp === 0) {
-        throw new self.constructor.NoRowsDeletedError('EmptyResponse');
+        throw new this.constructor.NoRowsDeletedError('EmptyResponse');
       }
       this.clear();
       return this.triggerThen('destroyed', this, resp, options);

--- a/test/integration/collection.js
+++ b/test/integration/collection.js
@@ -32,6 +32,19 @@ module.exports = function(bookshelf) {
     var Role     = Models.Role;
     var Photo    = Models.Photo;
 
+    describe('extend', function() {
+      it ('should have own EmptyError', function() {
+        var Sites = bookshelf.Collection.extend({model: Site});
+        var OtherSites = bookshelf.Collection.extend({model: Site});
+
+        var err = new Sites.EmptyError();
+        expect(Sites.EmptyError).to.not.be.eql(bookshelf.Collection.EmptyError);
+        expect(Sites.EmptyError).to.not.be.eql(OtherSites.EmptyError);
+        expect(Sites.EmptyError).to.not.be.eql(OtherSites.EmptyError);
+        expect(err).to.be.an.instanceof(bookshelf.Collection.EmptyError);
+      });
+    });
+
     describe('fetch', function() {
 
       it ('fetches the models in a collection', function() {

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -45,7 +45,7 @@ module.exports = function(bookshelf) {
       });
 
       it('can be extended', function() {
-        var user = new User();
+        var user = new User({name: "hoge"});
         var subUser = new SubUser();
         expect(user.idAttribute).to.equal('user_id');
         expect(user.getData()).to.equal('test');
@@ -70,21 +70,43 @@ module.exports = function(bookshelf) {
         expect((new User()).changedAttributes).to.be.undefined;
       });
 
-      it('should have own NotFoundError', function(){
-        expect(User.NotFoundError).to.be.eql(SubUser.NotFoundError);
-        expect(User.NotFoundError).to.not.be.eql(OtherUser.NotFoundError);
-      });
+      context('should have own errors: name of', function(){
+        it('NotFoundError', function(){
+          var err = new User.NotFoundError();
+          var suberr = new SubUser.NotFoundError();
+          expect(User.NotFoundError).to.not.be.eql(bookshelf.Model.NotFoundError);
+          expect(err).to.be.an.instanceof(bookshelf.Model.NotFoundError);
+          expect(User.NotFoundError).to.not.be.eql(SubUser.NotFoundError);
+          expect(err).to.not.be.an.instanceof(SubUser.NotFoundError);
+          expect(suberr).to.be.an.instanceof(User.NotFoundError);
+          expect(User.NotFoundError).to.not.be.eql(OtherUser.NotFoundError);
+          expect(err).to.not.be.an.instanceof(OtherUser.NotFoundError);
+        });
 
-      it('should have own NoRowsUpdatedError', function(){
-        expect(User.NoRowsUpdatedError).to.be.eql(SubUser.NoRowsUpdatedError);
-        expect(User.NoRowsUpdatedError).to.not.be.eql(OtherUser.NoRowsUpdatedError);
-      });
+        it('NoRowsUpdatedError', function(){
+          var err = new User.NoRowsUpdatedError();
+          var suberr = new SubUser.NoRowsUpdatedError();
+          expect(User.NoRowsUpdatedError).to.not.be.eql(bookshelf.Model.NoRowsUpdatedError);
+          expect(err).to.be.an.instanceof(bookshelf.Model.NoRowsUpdatedError);
+          expect(User.NoRowsUpdatedError).to.not.be.eql(SubUser.NoRowsUpdatedError);
+          expect(err).to.not.be.an.instanceof(SubUser.NoRowsUpdatedError);
+          expect(suberr).to.be.an.instanceof(User.NoRowsUpdatedError);
+          expect(User.NoRowsUpdatedError).to.not.be.eql(OtherUser.NoRowsUpdatedError);
+          expect(err).to.not.be.an.instanceof(OtherUser.NoRowsUpdatedError);
+        });
 
-      it('should have own NoRowsDeletedError', function(){
-        expect(User.NoRowsDeletedError).to.be.eql(SubUser.NoRowsDeletedError);
-        expect(User.NoRowsDeletedError).to.not.be.eql(OtherUser.NoRowsDeletedError);
+        it('NoRowsDeletedError', function(){
+          var err = new User.NoRowsDeletedError();
+          var suberr = new SubUser.NoRowsDeletedError();
+          expect(User.NoRowsDeletedError).to.not.be.eql(bookshelf.Model.NoRowsDeletedError);
+          expect(err).to.be.an.instanceof(bookshelf.Model.NoRowsDeletedError);
+          expect(User.NoRowsDeletedError).to.not.be.eql(SubUser.NoRowsDeletedError);
+          expect(err).to.not.be.an.instanceof(SubUser.NoRowsDeletedError);
+          expect(suberr).to.be.an.instanceof(User.NoRowsDeletedError);
+          expect(User.NoRowsDeletedError).to.not.be.eql(OtherUser.NoRowsDeletedError);
+          expect(err).to.not.be.an.instanceof(OtherUser.NoRowsDeletedError);
+        });
       });
-
     });
 
     describe('forge', function() {

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -37,6 +37,13 @@ module.exports = function(bookshelf) {
         classMethod2: function() { return 'test2'; }
       });
 
+      var OtherUser = bookshelf.Model.extend({
+        idAttribute: 'user_id',
+        getData: function() { return 'test'; }
+      }, {
+        classMethod: function() { return 'test'; }
+      });
+
       it('can be extended', function() {
         var user = new User();
         var subUser = new SubUser();
@@ -61,6 +68,21 @@ module.exports = function(bookshelf) {
       it('doesnt have ommitted Backbone properties', function() {
         expect(User.prototype.changedAttributes).to.be.undefined;
         expect((new User()).changedAttributes).to.be.undefined;
+      });
+
+      it('should have own NotFoundError', function(){
+        expect(User.NotFoundError).to.be.eql(SubUser.NotFoundError);
+        expect(User.NotFoundError).to.not.be.eql(OtherUser.NotFoundError);
+      });
+
+      it('should have own NoRowsUpdatedError', function(){
+        expect(User.NoRowsUpdatedError).to.be.eql(SubUser.NoRowsUpdatedError);
+        expect(User.NoRowsUpdatedError).to.not.be.eql(OtherUser.NoRowsUpdatedError);
+      });
+
+      it('should have own NoRowsDeletedError', function(){
+        expect(User.NoRowsDeletedError).to.be.eql(SubUser.NoRowsDeletedError);
+        expect(User.NoRowsDeletedError).to.not.be.eql(OtherUser.NoRowsDeletedError);
       });
 
     });


### PR DESCRIPTION
In current version every `NotFoundError` is same as `Errors.NotFoundError`, thus we cannot discriminate the NotFoundError occurred from.

The p-r enables this problem by setting in static properties bellow:

```coffee-script
Foo = bookshelf.Model.extend {
  tableName: "foo"
}, {
  NotFoundError: createError(bookshelf.Model.NotFoundError, "FooNotFoundError")
}

Bar = bookshelf.Model.extend {
  tableName: "bar"
}, {
  NotFoundError: createError(bookshelf.Model.NotFoundError, "BarNotFoundError")
}

Baz = bookshelf.Model.extend {
  tableName: "baz"
}

console.log Bar.NotFoundError is Foo.NotFoundError # => false

Foo.where(name: "foo").fetch(require: true)
.catch((err)->
  console.log err # => { [FooNotFoundError: EmptyResponse] message: 'EmptyResponse' }
  console.log err instanceof bookshelf.Model.NotFoundError # => true
  console.log err instanceof Foo.NotFoundError # => true
  console.log err instanceof Bar.NotFoundError # => false
  console.log err instanceof Baz.NotFoundError # => true use default because not override
)
```