### PR TITLE
Fix binding on `parse` when processing model pivot

### DIFF
--- a/lib/relation.js
+++ b/lib/relation.js
@@ -510,11 +510,10 @@ var pivotHelpers = {
   _processModelPivot: Promise.method(function(method, item, options, data, fks) {
     var relatedData = this.relatedData
       , JoinModel   = relatedData.throughTarget
-      , instance    = new JoinModel
-      , parser      = instance.parse;
+      , instance    = new JoinModel;
 
-    fks = parser(fks);
-    data = parser(data);
+    fks = instance.parse(fks);
+    data = instance.parse(data);
 
     if (method === 'insert') {
       return instance.set(data).save(null, options);


### PR DESCRIPTION
`Relation._processModelPivot` unbound `parse` from its model instance.

This was an issue for me as my `parse` function references `this.parseKey`.