### PR TITLE
Fixed to `collection.load` example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1906,8 +1906,8 @@ new Stories().fetch({
   withRelated: 'author'
 }).tap(function(stories) {
   if (req.withComments) return stories.load(['comments.tags', 'comments.author']);
-}).then(function() {
-  console.log(JSON.stringify(stories));
+}).then(function(stories) {
+  console.log(stories.toJSON());
 });
 </code></pre>
 


### PR DESCRIPTION
Added missing argument to `then` and replaced use of `JSON.stringify` instead of `toJSON`.