### PR TITLE
Questioning initialization recommendation

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,19 +280,16 @@ var User = bookshelf.Model.extend({
   <p>
     This initialization should likely only ever happen once in your application, as it creates a connection pool for the current database, you should use the <tt>bookshelf</tt> instance returned throughout your library.
 
-    You'll need to store this instance created by the initialize somewhere in the application you can reference it. A common pattern to follow if you're using <b>express.js</b> is to set the client as a property on the app instance when your application starts, so you can easily reference it later:
+    You'll need to store this instance created by the initialize somewhere in the application you can reference it. A common pattern to follow is to initialize the client in a module so you can easily reference it later:
   </p>
 
 <pre><code>
-// When the app starts
-var app = express();
+// In a file named something like bookshelf.js
 var knex = require('knex')(dbConfig);
-var bookshelf = require('bookshelf')(knex);
-
-app.set('bookshelf', bookshelf);
+module.exports require('bookshelf')(knex);
 
 // elsewhere, to use the bookshelf client:
-var bookshelf = app.get('bookshelf');
+var bookshelf = require('./bookshelf');
 
 var Post = bookshelf.Model.extend({
   // ...


### PR DESCRIPTION
Currently in the documentation, the recommendation for express
applications is to set the Bookshelf instance onto your application.  I
find this to be not only an odd choice, but also a limiting one.

In Node, if you want something memoized easily, the best way to achieve
that is through a module.  They are cached after the first invocation
and provide the exact solution described.

My problem with the current recommendation is that you create a
completely unnecesary dependency on the express app from your model
definition.  This is limiting in so many ways, especially with regards
to testing.

I don't think it hurts to attach the bookshelf instance to your app, and
that may make sense for a lot operations, but for Model definitions I
don't see why you'd ever want this.

What do you think?