### PR TITLE
docs: mention .asCallback instead of .exec

### DIFF
--- a/index.html
+++ b/index.html
@@ -2256,7 +2256,7 @@ Bookshelf.transaction(function(t) {
 
     <p id="faq-callbacks">
       <b class="header">Can I use standard node.js style callbacks.</b><br />
-      Yes - you can call <tt>.exec(function(err, resp) {</tt> on any "sync" method and
+      Yes - you can call <tt>.asCallback(function(err, resp) {</tt> on any "sync" method and
       use the standard <tt>(err, result)</tt> style callback interface if you prefer.
     </p>
 


### PR DESCRIPTION
Reflects deprecation warning on 0.8.0: "bookshelf.exec has been deprecated, please use bookshelf.asCallback instead"