### PR TITLE
fix model.id premature update with idAttribute

### DIFF
--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -60,7 +60,7 @@ ModelBase.prototype.set = function(key, val, options) {
   var prev    = this._previousAttributes;
 
   // Check for changes of `id`.
-  if (this.idAttribute in attrs) this.id = attrs[this.idAttribute];
+  if (this.idAttribute in current) this.id = current[this.idAttribute];
 
   // For each `set` attribute, update or delete the current value.
   for (var attr in attrs) {


### PR DESCRIPTION
Bug fix for when model.id is updated with model.idAttribute regardless of whether it is a new or existing instance