### PR TITLE
Fix foreign key assignment in `create()` on `hasMany(...).through(...)` relations.

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -94,7 +94,7 @@ var BookshelfCollection = CollectionBase.extend({
       .save(null, options)
       .bind(this)
       .then(function() {
-        if (relatedData && (relatedData.type === 'belongsToMany' || relatedData.isThrough())) {
+        if (relatedData && relatedData.type === 'belongsToMany') {
           return this.attach(model, _.omit(options, 'query'));
         }
       })

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -8,7 +8,11 @@ var helpers = {
   // Sets the constraints necessary during a `model.save` call.
   saveConstraints: function(model, relatedData) {
     var data = {};
-    if (relatedData && relatedData.type && relatedData.type !== 'belongsToMany' && relatedData.type !== 'belongsTo') {
+    if (relatedData
+        && !relatedData.isThrough()
+        && relatedData.type !== 'belongsToMany'
+        && relatedData.type !== 'belongsTo'
+    ) {
       data[relatedData.key('foreignKey')] = relatedData.parentFk || model.get(relatedData.key('foreignKey'));
       if (relatedData.isMorph()) data[relatedData.key('morphKey')] = relatedData.key('morphValue');
     }

--- a/test/integration/collection.js
+++ b/test/integration/collection.js
@@ -157,6 +157,17 @@ module.exports = function(bookshelf) {
 
       });
 
+      it('should not set incorrect foreign key in a `hasMany` `through` relation - #768', function() {
+
+        // This will fail if an unknown field (eg. `blog_id`) is added to insert query.
+        return new Blog({id: 768})
+          .comments()
+          .create({post_id: 5, comment: 'test comment'})
+          .tap(function (comment) {
+            return comment.destroy();
+          });
+      });
+
       it('should automatically create a join model when joining a belongsToMany', function() {
 
         return new Site({id: 1})

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -142,12 +142,10 @@ module.exports = function(Bookshelf) {
   var Post = Bookshelf.Model.extend({
     tableName: 'posts',
     defaults: {
-      author: '',
-      title: '',
-      body: '',
-      published: false
+      name: '',
+      content: ''
     },
-    hasTimestamps: true,
+    hasTimestamps: false,
     blog: function() {
       return this.belongsTo(Blog);
     },
@@ -175,7 +173,7 @@ module.exports = function(Bookshelf) {
     tableName: 'comments',
     defaults: {
       email: '',
-      post: ''
+      comment: ''
     },
     posts: function() {
       return this.belongsTo(Post);


### PR DESCRIPTION
Fixes #768. I've disabled some undocumented behaviour: implicitly creating 'joining models' when calling `create` on a `through` relation Collection. I've included my rationale in the commit messages.

I think that probably there are cases where one would like a joining model to be automatically made for a `through` relation. It makes sense for a many-to-many relationship. For the `hasMany` variant though, the FKs were being assigned to the wrong models and it would have required a fair bit of work and assumptions on my part about how it should behave. I also think there should be an option flag like 'createPivot', because in some cases you may wish to supply the FK of an existing through target model (as opposed to having it try to create a new one).