### PR TITLE
Allow default `Collection` type to be modified by plugins.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ function Bookshelf(knex) {
     forge: forge,
 
     collection: function(rows, options) {
-      return new Collection((rows || []), _.extend({}, options, {model: this}));
+      return new bookshelf.Collection((rows || []), _.extend({}, options, {model: this}));
     },
 
     fetchAll: function(options) {

--- a/lib/relation.js
+++ b/lib/relation.js
@@ -236,9 +236,7 @@ var BookshelfRelation = RelationBase.extend({
     // Allows us to just use a model, but create a temporary
     // collection for a "*-many" relation.
     if (Target.prototype instanceof ModelBase) {
-      Target = this.Collection.extend({
-        model: Target
-      });
+      return Target.collection(models, {parse: true});
     }
     return new Target(models, {parse: true});
   },

--- a/test/integration/plugin.js
+++ b/test/integration/plugin.js
@@ -11,6 +11,11 @@ module.exports = function (Bookshelf) {
 
   describe('Plugin', function () {
 
+    var Models = require('./helpers/objects')(Bookshelf).Models;
+
+    var Site   = Models.Site;
+    var Author = Models.Author;
+
     it('can be the name of an included plugin', function () {
       Bookshelf.plugin('registry');
       expect(Bookshelf).to.itself.respondTo('model');
@@ -34,6 +39,22 @@ module.exports = function (Bookshelf) {
 
     it('returns the Bookshelf instance for chaining', function () {
       expect(Bookshelf.plugin(spy, options)).to.equal(Bookshelf);
+    });
+
+    it('can modify the `Collection` model returned by `Model#collection`', function () {
+      var testPlugin = function (bookshelf, options) {
+        bookshelf.Collection = bookshelf.Collection.extend({
+          test: 'test'
+        });
+      }
+
+      Bookshelf.plugin(testPlugin);
+      expect(Bookshelf.Model.collection().test).to.equal('test');
+    });
+
+    it('can modify the `Collection` model used by relations', function () {
+      var authors = Site.forge().related('authors');
+      expect(authors.test).to.equal('test');
     });
 
   });


### PR DESCRIPTION
Hey guys, I know there probably isn't strong support for these changes (esp. because they pertain to collections). Nonetheless, I'd *really* appreciate if this was merged.

I use a fair few custom extensions to bookshelf, but there are features that I'd really prefer to build into the `Collection` type. At the moment the only way to do this would be to maintain and update my own fork, which seems kind of silly when the project has plugin support...

I tried to do this with a minimal set of changes. If you dislike my approach I'm happy to make changes until it fits.

Fixes tgriesser/bookshelf#681, fixes tgriesser/bookshelf#688.