### PR TITLE
Restore `Model#clone`.

### DIFF
--- a/lib/base/collection.js
+++ b/lib/base/collection.js
@@ -34,7 +34,7 @@ inherits(CollectionBase, Events);
 // `relatedData` does not mutate itself after declaration. This is only
 // here because `clone` needs to duplicate this property. It should not
 // be documented as a valid argument for consumer code.
-var collectionProps = ['model', 'Model', 'comparator', 'relatedData'];
+var collectionProps = ['model', 'comparator', 'relatedData'];
 
 // Copied over from Backbone.
 var setOptions = {add: true, remove: true, merge: true};

--- a/lib/base/collection.js
+++ b/lib/base/collection.js
@@ -326,7 +326,7 @@ CollectionBase.prototype.parse = function(resp, options) {
 
 // Create a new collection with an identical list of models as this one.
 CollectionBase.prototype.clone = function() {
-  return new this.constructor(this.models, this);
+  return new this.constructor(this.models, _.pick(this, collectionProps));
 };
 
 // Private method to reset all internal state. Called when the collection

--- a/lib/base/collection.js
+++ b/lib/base/collection.js
@@ -14,6 +14,7 @@ var array  = [];
 var push   = array.push;
 var slice  = array.slice;
 var splice = array.splice;
+var noop   = _.noop;
 
 function CollectionBase(models, options) {
   if (options) _.extend(this, _.pick(options, collectionProps));
@@ -27,13 +28,19 @@ function CollectionBase(models, options) {
 inherits(CollectionBase, Events);
 
 // List of attributes attached directly from the constructor's options object.
-var collectionProps = ['model', 'Model', 'comparator'];
+//
+// RE: 'relatedData'
+// It's okay for two `Collection`s to share a `Relation` instance.
+// `relatedData` does not mutate itself after declaration. This is only
+// here because `clone` needs to duplicate this property. It should not
+// be documented as a valid argument for consumer code.
+var collectionProps = ['model', 'Model', 'comparator', 'relatedData'];
 
 // Copied over from Backbone.
 var setOptions = {add: true, remove: true, merge: true};
 var addOptions = {add: true, remove: false};
 
-CollectionBase.prototype.initialize = function() {};
+CollectionBase.prototype.initialize = noop;
 
 // The `tableName` on the associated Model, used in relation building.
 CollectionBase.prototype.tableName = function() {
@@ -319,7 +326,7 @@ CollectionBase.prototype.parse = function(resp, options) {
 
 // Create a new collection with an identical list of models as this one.
 CollectionBase.prototype.clone = function() {
-  return new this.constructor(this.models);
+  return new this.constructor(this.models, this);
 };
 
 // Private method to reset all internal state. Called when the collection

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -164,7 +164,7 @@ ModelBase.prototype.clone = function(options) {
     model.relations[key] = relations[key].clone();
   }
   model._previousAttributes = _.clone(this._previousAttributes);
-  model.changed = setProps(Object.create(null), this.changed);
+  model.changed = _.clone(this.changed);
   return model;
 };
 
@@ -233,15 +233,6 @@ ModelBase.prototype._reset = function() {
   this.changed = Object.create(null);
   return this;
 };
-
-// Set the changed properties on the object.
-function setProps(obj, hash) {
-  var i = -1, keys = Object.keys(hash);
-  while (++i < hash.length) {
-    var key = hash[i]
-    obj[key] = hash[key];
-  }
-}
 
 // "_" methods that we want to implement on the Model.
 var modelMethods = ['keys', 'values', 'pairs', 'invert', 'pick', 'omit'];

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -102,15 +102,6 @@ var BookshelfCollection = CollectionBase.extend({
       .return(model);
   }),
 
-  // Returns a new instance of the collection with an identical list of models.
-  clone: function() {
-    var collection = CollectionBase.prototype.clone.apply(this);
-    // It's okay for two `Collection`s to share a `Relation` instance.
-    // `relatedData` does not mutate itself after declaration.
-    collection.relatedData = this.relatedData;
-    return collection;
-  },
-
   // Reset the query builder, called internally
   // each time a query is run.
   resetQuery: function() {

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -102,8 +102,11 @@ var BookshelfCollection = CollectionBase.extend({
       .return(model);
   }),
 
+  // Returns a new instance of the collection with an identical list of models.
   clone: function() {
     var collection = CollectionBase.prototype.clone.apply(this);
+    // It's okay for two `Collection`s to share a `Relation` instance.
+    // `relatedData` does not mutate itself after declaration.
     collection.relatedData = this.relatedData;
     return collection;
   },

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -102,6 +102,12 @@ var BookshelfCollection = CollectionBase.extend({
       .return(model);
   }),
 
+  clone: function() {
+    var collection = CollectionBase.prototype.clone.apply(this);
+    collection.relatedData = this.relatedData;
+    return collection;
+  },
+
   // Reset the query builder, called internally
   // each time a query is run.
   resetQuery: function() {

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -829,6 +829,18 @@ module.exports = function(bookshelf) {
 
     });
 
+    describe('clone', function() {
+      var Post = Models.Post;
+
+      it('should be equivalent when cloned', function() {
+        var original = Post.forge({author: 'Johnny', body: 'body'});
+        original.related('comments').add({email: 'some@email.com'});
+        var cloned = original.clone();
+
+        deepEqual(_.omit(cloned, 'cid'), _.omit(original, 'cid'));
+      });
+    });
+
   });
 
 };

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -829,7 +829,7 @@ module.exports = function(bookshelf) {
 
     });
 
-    describe('clone', function() {
+    describe('model.clone', function() {
       var Post = Models.Post;
 
       it('should be equivalent when cloned', function() {


### PR DESCRIPTION
 - Fixed bug in `Model#clone` where `model.changed` was being set to `undefined`.
 - Remove broken `setProps` helper function, and use `_.clone` instead.
 - Modify `CollectionBase#clone` to pass model constructor and relatedData to the new instance. This is important for keeping behaviour between cloned relations. This should be okay because the `relatedData` object holds no references to its `parent`, and appears to be immutable after declaration.
 - Add simple test for equivalence between copies.

Fixes tgriesser/bookshelf#744