### PR TITLE
Add assignment operator on line 291 of Bookshelf documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,7 +288,7 @@ var User = bookshelf.Model.extend({
 <pre><code>
 // In a file named something like bookshelf.js
 var knex = require('knex')(dbConfig);
-module.exports require('bookshelf')(knex);
+module.exports = require('bookshelf')(knex);
 
 // elsewhere, to use the bookshelf client:
 var bookshelf = require('./bookshelf');


### PR DESCRIPTION
Edit to 'Installation' section of documentation. Added missing assignment operator.

Before:
// In a file named something like bookshelf.js
var knex = require('knex')(dbConfig);
module.exports require('bookshelf')(knex);

After:
// In a file named something like bookshelf.js
var knex = require('knex')(dbConfig);
module.exports = require('bookshelf')(knex);