### PR TITLE
Add `Collection#count`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
       <li>– <a href="#Model-refresh">refresh</a></li>
       <li>– <a href="#Model-fetch">fetch</a></li>
       <li>– <a href="#Model-fetchAll">fetchAll</a></li>
+      <li>– <a href="#Model-count">count</a></li>
       <li>– <a href="#Model-where">where</a></li>
       <li>– <a href="#Model-query">query</a></li>
       <li>– <a href="#Model-load">load</a></li>
@@ -122,6 +123,7 @@
       <li>– <a href="#Collection-toJSON">toJSON</a></li>
       <li>– <a href="#Collection-fetch">fetch</a></li>
       <li>– <a href="#Collection-fetchOne">fetchOne</a></li>
+      <li>– <a href="#Collection-count">count</a></li>
       <li>– <a href="#Collection-mapThen">mapThen</a></li>
       <li>– <a href="#Collection-invokeThen">invokeThen</a></li>
       <li>– <a href="#Collection-load">load</a></li>
@@ -582,6 +584,17 @@ new Book({'ISBN-13': '9780440180296'}).fetch({
       <br />
       Fetches a <a href="#Collection">collection</a> of models from the database, using any <a href="#Model-query">query</a> parameters currently set on the model to form a <tt>select</tt> query. Returns a promise, which will resolve with the fetched <tt>collection</tt>. If you wish to trigger an error if no models are found, pass <tt>{require: true}</tt> as one of the options to the fetchAll call. A <tt>"fetching"</tt> event will be fired just before the collection is fetched; a good place to hook into for validations. A <tt>"fetched"</tt> event will be fired when a record is successfully retrieved. If you need to constrain the query performed by fetch, you can call the <a href="#Model-query">query</a> method before calling fetch.
     </p>
+
+    <p id="Model-count">
+      <b class="header">count</b><code>Model.count / model.count(column='*', [options]).then(function(count) { ...</code>
+      <br>
+      Gets the number of matching records in the database, respecting any previous calls to <a href="#Model-query">query</a>. If a <tt>column</tt> if provided, records with a null value in that column will be excluded from the count.
+
+<pre><code>
+// Get the number of named, blue ducks.
+Duck.where('color', 'blue').count('name')
+  .then(function(count) { //...
+</code></pre>
 
     <p id="Model-load">
       <b class="header">load</b><code>model.load(relations, [options]).then(function(model) {...</code>
@@ -1833,6 +1846,24 @@ new Site({id:1})
   });
 </code></pre>
 
+    <p id="Collection-count">
+      <b class="header">count</b><code>collection.count(column='*', [options])</code>
+      <br>
+      Get the number of records in the collection's table. Providing a <tt>column</tt>
+      value excludes records with a null value in that column.
+    </p>
+
+<pre><code>
+// select count(*) from shareholders where company_id = 1 and share &gt; 0.1;
+new Company({id:1})
+  .shareholders()
+  .query('where', 'share', '&gt;', '0.1')
+  .count()
+  .then(function(count) {
+    assert(count === 3);
+  });
+</code></pre>
+
     <p id="Collection-mapThen">
       <b class="header">mapThen</b><code>collection.mapThen(iterator, [context])</code>
       <br />
@@ -2344,6 +2375,9 @@ process.stderr.on('data', function(data) {
     <ul>
       <li>
         ES6/7: Move code base to <tt>/src</tt> &mdash; code is now compiled into <tt>/lib</tt> via <a href="https://babeljs.io/">Babel</a>.
+      </li>
+      <li>
+        Add <tt><a href="#Collection-count">collection.count</a>, <tt><a href="#Model-count">model.count</a></tt> and <tt>Model.count</tt>.
       </li>
       <li>
         Add <tt><a href="#Model-refresh">model.refresh</a></tt>. #796

--- a/lib/bookshelf.js
+++ b/lib/bookshelf.js
@@ -47,6 +47,10 @@ function Bookshelf(knex) {
       return new bookshelf.Collection(rows || [], _.extend({}, options, { model: this }));
     },
 
+    count: function count(column, options) {
+      return this.forge().count(column, options);
+    },
+
     fetchAll: function fetchAll(options) {
       return this.forge().fetchAll(options);
     }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -51,6 +51,17 @@ var BookshelfCollection = CollectionBase.extend({
     })['return'](this);
   }),
 
+  // Counts all models in collection, respecting relational constrains and query
+  // modifications.
+  count: Promise.method(function (column, options) {
+    if (!_.isString(column)) {
+      options = column;
+      column = undefined;
+    }
+    if (options) options = _.clone(options);
+    return this.sync(options).count(column);
+  }),
+
   // Fetches a single model from the collection, useful on related collections.
   fetchOne: Promise.method(function (options) {
     var model = new this.model();

--- a/lib/model.js
+++ b/lib/model.js
@@ -131,14 +131,23 @@ var BookshelfModel = ModelBase.extend({
     });
   }),
 
-  // Shortcut for creating a collection and fetching the associated models.
-  fetchAll: function fetchAll(options) {
-    var _this = this;
-
+  all: function all() {
     var collection = this.constructor.collection();
     collection._knex = this.query().clone();
     this.resetQuery();
     if (this.relatedData) collection.relatedData = this.relatedData;
+    return collection;
+  },
+
+  count: function count(column, options) {
+    return this.all().count(column, options);
+  },
+
+  // Shortcut for creating a collection and fetching the associated models.
+  fetchAll: function fetchAll(options) {
+    var _this = this;
+
+    var collection = this.all();
     return collection.once('fetching', function (__, columns, opts) {
       return _this.triggerThen('fetching:collection', collection, columns, opts);
     }).once('fetched', function (__, resp, opts) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -85,7 +85,7 @@ var BookshelfModel = ModelBase.extend({
     // primary key.
     var attributes = this.isNew() ? this.attributes : _.pick(this.attributes, this.idAttribute);
 
-    return this._doRefresh(attributes, options);
+    return this._doFetch(attributes, options);
   },
 
   // Fetch a model based on the currently set attributes, returning a model to
@@ -95,10 +95,10 @@ var BookshelfModel = ModelBase.extend({
   fetch: function fetch(options) {
 
     // Fetch uses all set attributes.
-    return this._doRefresh(this.attributes, options);
+    return this._doFetch(this.attributes, options);
   },
 
-  _doRefresh: Promise.method(function (attributes, options) {
+  _doFetch: Promise.method(function (attributes, options) {
     options = options ? _.clone(options) : {};
 
     // Run the `first` call on the `sync` object to fetch a single model.

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -60,6 +60,48 @@ _.extend(Sync.prototype, {
     return this.select();
   }),
 
+  // Add relational constraints required for either a `count` or `select` query.
+  constrain: Promise.method(function () {
+    var knex = this.query,
+        options = this.options,
+        relatedData = this.syncing.relatedData,
+        fks = {},
+        through;
+
+    // Set the query builder on the options, in-case we need to
+    // access in the `fetching` event handlers.
+    options.query = knex;
+
+    // Inject all appropriate select costraints dealing with the relation
+    // into the `knex` query builder for the current instance.
+    if (relatedData) return Promise['try'](function () {
+      if (relatedData.isThrough()) {
+        fks[relatedData.key('foreignKey')] = relatedData.parentFk;
+        through = new relatedData.throughTarget(fks);
+        return through.triggerThen('fetching', through, relatedData.pivotColumns, options).then(function () {
+          relatedData.pivotColumns = through.parse(relatedData.pivotColumns);
+        });
+      }
+    });
+  }),
+
+  // Runs a `count` query on the database, adding any necessary relational
+  // constraints. Returns a promise that resolves to an integer count.
+  count: Promise.method(function (column) {
+    var knex = this.query,
+        options = this.options;
+
+    return Promise.bind(this).then(function () {
+      return this.constrain();
+    }).then(function () {
+      return this.syncing.triggerThen('counting', this.syncing, options);
+    }).then(function () {
+      return knex.count((column || '*') + ' as count');
+    }).then(function (rows) {
+      return rows[0].count;
+    });
+  }),
+
   // Runs a `select` query on the database, adding any necessary relational
   // constraints, resetting the query when complete. If there are results and
   // eager loaded relations, those are fetched and returned on the model before
@@ -93,24 +135,9 @@ _.extend(Sync.prototype, {
     options.query = knex;
 
     return Promise.bind(this).then(function () {
-      var fks = {},
-          through;
-
-      // Inject all appropriate select costraints dealing with the relation
-      // into the `knex` query builder for the current instance.
-      if (relatedData) {
-        if (relatedData.throughTarget) {
-          fks[relatedData.key('foreignKey')] = relatedData.parentFk;
-          through = new relatedData.throughTarget(fks);
-          return through.triggerThen('fetching', through, relatedData.pivotColumns, options).then(function () {
-            relatedData.pivotColumns = through.parse(relatedData.pivotColumns);
-            relatedData.selectConstraints(knex, options);
-          });
-        } else {
-          relatedData.selectConstraints(knex, options);
-        }
-      }
+      return this.constrain();
     }).then(function () {
+      if (relatedData) relatedData.selectConstraints(knex, options);
       return this.syncing.triggerThen('fetching', this.syncing, columns, options);
     }).then(function () {
       return knex.select(columns);

--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -46,6 +46,10 @@ function Bookshelf(knex) {
       return new bookshelf.Collection((rows || []), _.extend({}, options, {model: this}));
     },
 
+    count: function(column, options) {
+      return this.forge().count(column, options); 
+    },
+
     fetchAll: function(options) {
       return this.forge().fetchAll(options); 
     }

--- a/src/collection.js
+++ b/src/collection.js
@@ -55,6 +55,17 @@ var BookshelfCollection = CollectionBase.extend({
       .return(this);
   }),
 
+  // Counts all models in collection, respecting relational constrains and query
+  // modifications.
+  count: Promise.method(function(column, options) {
+    if (!_.isString(column)) {
+      options = column;
+      column = undefined;
+    }
+    if (options) options = _.clone(options);
+    return this.sync(options).count(column)
+  }),
+
   // Fetches a single model from the collection, useful on related collections.
   fetchOne: Promise.method(function(options) {
     var model = new this.model();

--- a/src/model.js
+++ b/src/model.js
@@ -137,12 +137,21 @@ var BookshelfModel = ModelBase.extend({
       });
   }),
 
-  // Shortcut for creating a collection and fetching the associated models.
-  fetchAll: function(options) {
-    var collection = this.constructor.collection();
+  all: function() {
+    let collection = this.constructor.collection();
     collection._knex = this.query().clone();
     this.resetQuery();
     if (this.relatedData) collection.relatedData = this.relatedData;
+    return collection;
+  },
+
+  count: function(column, options) {
+    return this.all().count(column, options);
+  },
+
+  // Shortcut for creating a collection and fetching the associated models.
+  fetchAll: function(options) {
+    let collection = this.all();
     return collection
       .once('fetching', (__, columns, opts) => {
         return this.triggerThen('fetching:collection', collection, columns, opts);

--- a/test/integration/helpers/inserts.js
+++ b/test/integration/helpers/inserts.js
@@ -73,6 +73,10 @@ module.exports = function(bookshelf) {
       site_id: 2,
       first_name: 'Ron',
       last_name: 'Burgundy'
+    },{
+      site_id: 99,
+      first_name: 'Anonymous',
+      last_name: null
     }]),
 
     knex('posts').insert([{

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -866,6 +866,14 @@ module.exports = function(bookshelf) {
 
     });
 
+    describe('Model.count', function() {
+      it('counts the number of matching records in the database', function() {
+        return Models.Post.count().then(function(count) {
+          checkCount(count, 5);
+        });
+      });
+    });
+
     describe('model.once', function() {
 
       var Post = Models.Post;

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -599,7 +599,7 @@ module.exports = function(bookshelf) {
     });
 
     describe('count', function() {
-      it ('counts the number of models in a collection', function() {
+      it('counts the number of models in a collection', function() {
         return Models.Post
           .forge()
           .count()
@@ -608,7 +608,7 @@ module.exports = function(bookshelf) {
           });
       });
 
-      it ('optionally counts by column (excluding null values)', function() {
+      it('optionally counts by column (excluding null values)', function() {
         var author = Models.Author.forge();
         return author.count()
           .then(function(count) {
@@ -619,7 +619,7 @@ module.exports = function(bookshelf) {
           });
       });
 
-      it ('counts a filtered query', function() {
+      it('counts a filtered query', function() {
         return Models.Post
           .forge()
           .query('where', 'blog_id', 1)
@@ -627,6 +627,16 @@ module.exports = function(bookshelf) {
           .then(function(count) {
             checkCount(count, 2);
           });
+      });
+
+      it('resets query after completing', function() {
+        var posts =  Models.Post.collection();
+        posts.query('where', 'blog_id', 2).count()
+          .then(function(count)  {
+            checkCount(count, 2);
+            return posts.count();
+          })
+          .then(function(count) { checkCount(count, 2); });
       });
 
     });

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -3608,6 +3608,12 @@ module.exports = {
           _pivot_owner_id: 4,
           _pivot_blog_id: 4
         }]
+      },{
+        id: 5,
+        site_id: 99,
+        first_name: 'Anonymous',
+        last_name: null,
+        blogs: []
       }]
     },
     postgresql: {
@@ -3670,6 +3676,12 @@ module.exports = {
           _pivot_owner_id: 4,
           _pivot_blog_id: 4
         }]
+      },{
+        id: 5,
+        site_id: 99,
+        first_name: 'Anonymous',
+        last_name: null,
+        blogs: []
       }]
     },
     sqlite3: {
@@ -3732,6 +3744,12 @@ module.exports = {
           _pivot_owner_id: 4,
           _pivot_blog_id: 4
         }]
+      },{
+        id: 5,
+        site_id: 99,
+        first_name: 'Anonymous',
+        last_name: null,
+        blogs: []
       }]
     }
   },


### PR DESCRIPTION
Returns a promise that resolves to the number of elements that would be returned by a `fetchAll`. Respects relational constraints. Resets query afterwards, in keeping with behaviour for `fetch`.

First attempt at addressing tgriesser/bookshelf#126

This seemed a lot more straight forward than I expected, which makes me suspect that I've missed something important. At worst it will require documentation before merging.

I'd really like someone to take a look at this and tell me what they think. @tgriesser?