### PR TITLE
Fix `ModelBase#timestamp` behaviour.

### DIFF
--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -174,7 +174,7 @@ ModelBase.prototype.timestamp = function(options) {
   var keys = (_.isArray(this.hasTimestamps) ? this.hasTimestamps : ['created_at', 'updated_at']);
   var vals = {};
   if (keys[1]) vals[keys[1]] = d;
-  if (this.isNew(options) && keys[0] && (!options || options.method !== 'update')) vals[keys[0]] = d;
+  if (keys[0] && (this.isNew(options) || (options && options.method === 'insert'))) vals[keys[0]] = d;
   return vals;
 };
 

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -169,6 +169,9 @@ ModelBase.prototype.clone = function(options) {
 };
 
 // Returns the method that will be used on save, either 'update' or 'insert'.
+// This is an internal helper that uses `isNew` and `options.method` to
+// determine the correct method. If `option.method` is provided, it will be
+// returned, but lowercased for later comparison.
 ModelBase.prototype.saveMethod = function(options) {
   var method = options && options.method && options.method.toLowerCase();
   return method || (this.isNew(options) ? 'insert' : 'update');

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -175,7 +175,14 @@ ModelBase.prototype.timestamp = function(options) {
   var keys = (_.isArray(this.hasTimestamps) ? this.hasTimestamps : ['created_at', 'updated_at']);
   var vals = {};
   if (keys[1]) vals[keys[1]] = d;
-  if(keys[0] && options.method === 'insert' || (!options.method && this.isNew(options))) vals[keys[0]] = d;
+  // Method overload
+  if(options.method){
+    // Set createdAt only if insert
+    if(options.method === 'insert') vals[keys[0]] = d;
+  }
+  // No method to overload isNew()
+  else if(this.isNew(options)) vals[keys[0]] = d;
+
   return vals;
 };
 

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -168,22 +168,31 @@ ModelBase.prototype.clone = function(options) {
   return model;
 };
 
-// Sets the timestamps before saving the model.
-ModelBase.prototype.timestamp = function(options) {
-  options = options || {};
-  var d = new Date();
-  var keys = (_.isArray(this.hasTimestamps) ? this.hasTimestamps : ['created_at', 'updated_at']);
-  var vals = {};
-  if (keys[1]) vals[keys[1]] = d;
-  // Method overload
-  if(options.method){
-    // Set createdAt only if insert
-    if(options.method === 'insert') vals[keys[0]] = d;
-  }
-  // No method to overload isNew()
-  else if(this.isNew(options)) vals[keys[0]] = d;
+// Returns the method that will be used on save, either 'update' or 'insert'.
+ModelBase.prototype.saveMethod = function(options) {
+  var method = options && options.method && options.method.toLowerCase();
+  return method || (this.isNew(options) ? 'insert' : 'update');
+};
 
-  return vals;
+// Returns the timestamp values to be set on save.
+ModelBase.prototype.timestamp = function(options) {
+  var now          = new Date();
+  var attributes   = {};
+  var method       = this.saveMethod(options);
+  var keys         = _.isArray(this.hasTimestamps) ? this.hasTimestamps : ['created_at', 'updated_at'];
+  var createdAtKey = keys[0];
+  var updatedAtKey = keys[1];
+
+  if (updatedAtKey) {
+    attributes[updatedAtKey] = now;
+  }
+
+  if (createdAtKey && method === 'insert') {
+    attributes[createdAtKey] = now;
+  }
+
+
+  return attributes;
 };
 
 // Determine if the model has changed since the last `"change"` event.

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -177,8 +177,15 @@ ModelBase.prototype.saveMethod = function(options) {
   return method || (this.isNew(options) ? 'insert' : 'update');
 };
 
-// Returns the timestamp values to be set on save.
+// Sets the timestamp attributes on the model, if `hasTimestamps` is set to true
+// or an array. Check if the model `isNew` or if `{method: 'insert'}` is
+// provided as an option and set the `created_at` and `updated_at` attributes to
+// the current date if it is being inserted, and just the `updated_at` attribute
+// if it's being updated. This method may be overriden to use different column
+// names or types for the timestamps.
 ModelBase.prototype.timestamp = function(options) {
+  if (!this.hasTimestamps) return {};
+
   var now          = new Date();
   var attributes   = {};
   var method       = this.saveMethod(options);
@@ -194,6 +201,7 @@ ModelBase.prototype.timestamp = function(options) {
     attributes[createdAtKey] = now;
   }
 
+  this.set(attributes, options);
 
   return attributes;
 };

--- a/lib/base/model.js
+++ b/lib/base/model.js
@@ -170,11 +170,12 @@ ModelBase.prototype.clone = function(options) {
 
 // Sets the timestamps before saving the model.
 ModelBase.prototype.timestamp = function(options) {
+  options = options || {};
   var d = new Date();
   var keys = (_.isArray(this.hasTimestamps) ? this.hasTimestamps : ['created_at', 'updated_at']);
   var vals = {};
   if (keys[1]) vals[keys[1]] = d;
-  if (keys[0] && (this.isNew(options) || (options && options.method === 'insert'))) vals[keys[0]] = d;
+  if(keys[0] && options.method === 'insert' || (!options.method && this.isNew(options))) vals[keys[0]] = d;
   return vals;
 };
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -170,27 +170,24 @@ var BookshelfModel = ModelBase.extend({
       return this.isNew(options);
     }).then(function(isNew) {
 
-      // If the model has timestamp columns,
-      // set them as attributes on the model, even
-      // if the "patch" option is specified.
+      // Determine whether which kind of save we will do, update or insert.
+      var method = options.method = this.saveMethod(options);
+
+      // If the model has timestamp columns, set them as attributes on the
+      // model, even if the "patch" option is specified.
       if (this.hasTimestamps) _.extend(attrs, this.timestamp(options));
 
-      // Determine whether the model is new, based on whether the model has an `idAttribute` or not.
-      options.method = (options.method || (isNew ? 'insert' : 'update')).toLowerCase();
-      var method = options.method;
-      var vals = attrs;
-
-      // If the object is being created, we merge any defaults here
-      // rather than during object creation.
+      // If the object is being created, we merge any defaults here rather than
+      // during object creation.
       if (method === 'insert' || options.defaults) {
         var defaults = _.result(this, 'defaults');
         if (defaults) {
-          vals = _.extend({}, defaults, this.attributes, vals);
+          attrs = _.extend({}, defaults, this.attributes, attrs);
         }
       }
 
       // Set the attributes on the model.
-      this.set(vals, {silent: true});
+      this.set(attrs, {silent: true});
 
       // If there are any save constraints, set them on the model.
       if (this.relatedData && this.relatedData.type !== 'morphTo') {

--- a/lib/model.js
+++ b/lib/model.js
@@ -173,10 +173,6 @@ var BookshelfModel = ModelBase.extend({
       // Determine whether which kind of save we will do, update or insert.
       var method = options.method = this.saveMethod(options);
 
-      // If the model has timestamp columns, set them as attributes on the
-      // model, even if the "patch" option is specified.
-      if (this.hasTimestamps) _.extend(attrs, this.timestamp(options));
-
       // If the object is being created, we merge any defaults here rather than
       // during object creation.
       if (method === 'insert' || options.defaults) {
@@ -186,8 +182,15 @@ var BookshelfModel = ModelBase.extend({
         }
       }
 
-      // Set the attributes on the model.
+      // Set the attributes on the model. Note that we do this before adding
+      // timestamps, as `timestamp` calls `set` internally.
       this.set(attrs, {silent: true});
+
+      // Now set timestamps if appropriate. Extend `attrs` so that the
+      // timestamps will be provided for a patch operation.
+      if (this.hasTimestamps) {
+        _.extend(attrs, this.timestamp({method: method, silent: true}));
+      }
 
       // If there are any save constraints, set them on the model.
       if (this.relatedData && this.relatedData.type !== 'morphTo') {

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -683,6 +683,13 @@ module.exports = function(bookshelf) {
         equal(_.isEmpty(ts2.created_at), true);
         equal(_.isDate(ts2.updated_at), true);
       });
+
+      it('will set the `created_at` when inserting new entries', function() {
+        var m = new bookshelf.Model({id: 1});
+        var ts  = m.timestamp({method: 'insert'});
+        equal(_.isDate(ts.created_at), true);
+        equal(_.isDate(ts.updated_at), true);
+      });
     });
 
     describe('defaults', function() {

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -674,21 +674,31 @@ module.exports = function(bookshelf) {
     describe('timestamp', function() {
 
       it('will set the `updated_at` attribute to a date, and the `created_at` for new entries', function() {
-        var m  = new bookshelf.Model();
-        var m1 = new bookshelf.Model({id: 1});
-        var ts  = m.timestamp();
-        var ts2 = m1.timestamp();
-        equal(_.isDate(ts.created_at), true);
-        equal(_.isDate(ts.updated_at), true);
-        equal(_.isEmpty(ts2.created_at), true);
-        equal(_.isDate(ts2.updated_at), true);
+        var newModel      = new bookshelf.Model({}, {hasTimestamps: true});
+        var existingModel = new bookshelf.Model({id: 1}, {hasTimestamps: true});
+        newModel.timestamp();
+        existingModel.timestamp();
+        expect(newModel.get('created_at')).to.be.an.instanceOf(Date);
+        expect(newModel.get('updated_at')).to.be.an.instanceOf(Date);
+
+        expect(existingModel.get('created_at')).to.not.exist;
+        expect(existingModel.get('updated_at')).to.be.an.instanceOf(Date);
       });
 
       it('will set the `created_at` when inserting new entries', function() {
-        var m = new bookshelf.Model({id: 1});
-        var ts  = m.timestamp({method: 'insert'});
-        equal(_.isDate(ts.created_at), true);
-        equal(_.isDate(ts.updated_at), true);
+        var model = new bookshelf.Model({id: 1}, {hasTimestamps: true});
+        model.timestamp({method: 'insert'});
+
+        expect(model.get('created_at')).to.be.an.instanceOf(Date);
+        expect(model.get('updated_at')).to.be.an.instanceOf(Date);
+      });
+
+      it('will not set timestamps on a model without `setTimestamps` set to true', function () {
+        var model = new bookshelf.Model();
+        model.timestamp();
+
+        expect(model.get('created_at')).to.not.exist;
+        expect(model.get('updated_at')).to.not.exist;
       });
     });
 


### PR DESCRIPTION
Fixes the following:
  - Timestamp attributes were not updated when `timestamp()` was called.
  - Tests for `timestamp()` were inconsistent with behaviour described in comments and documentation.
  - `createdAt` timestamp failed to be updated when saving a new model with an ID attribute, but explicitly passing `{method: 'insert'}`.
  - Calling `timestamp()` on a model with `hasTimestamps: false` set timestamps, now is a noop.
  - Refactor and update comments improve readability of `Model#save` and `ModelBase#timestamp`.

Closes #784, closes #785, closes #787.