### PR TITLE
`Model#refresh` and fixes to `fetch` behaviour.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -37,17 +37,35 @@ var helpers = {
   // If the first argument is an object, assume the keys are query builder
   // methods, and the values are the arguments for the query.
   query: function(obj, args) {
-    obj._knex = obj._knex || obj._builder(_.result(obj, 'tableName'));
+
+    // Ensure the object has a query builder.
+    if (!obj._knex) {
+      var tableName = _.result(obj, 'tableName');
+      obj._knex = obj._builder(tableName);
+    }
+
+    // If there are no arguments, return the query builder.
     if (args.length === 0) return obj._knex;
+
     var method = args[0];
+
     if (_.isFunction(method)) {
+
+      // `method` is a query builder callback. Call it on the query builder
+      // object.
       method.call(obj._knex, obj._knex);
     } else if (_.isObject(method)) {
+
+      // `method` is an object. Use keys as methods and values as arguments to
+      // the query builder.
       for (var key in method) {
         var target = _.isArray(method[key]) ?  method[key] : [method[key]];
         obj._knex[key].apply(obj._knex, target);
       }
     } else {
+
+      // Otherwise assume that the `method` is string name of a query builder
+      // method, and use the remaining args as arguments to that method.
       obj._knex[method].apply(obj._knex, args.slice(1));
     }
     return obj;

--- a/lib/model.js
+++ b/lib/model.js
@@ -74,17 +74,36 @@ var BookshelfModel = ModelBase.extend({
     return this.relatedData.through(this, Interim, {throughForeignKey: foreignKey, otherKey: otherKey});
   },
 
-  // Fetch a model based on the currently set attributes,
-  // returning a model to the callback, along with any options.
-  // Returns a deferred promise through the `Bookshelf.Sync`.
-  // If `{require: true}` is set as an option, the fetch is considered
-  // a failure if the model comes up blank.
-  fetch: Promise.method(function(options) {
+  // Update the attributes of a model, fetching it by its primary key. If
+  // no attribute matches its `idAttribute`, then fetch by all available
+  // fields.
+  refresh: function(options) {
+
+    // If this is new, we use all its attributes. Otherwise we just grab the
+    // primary key.
+    var attributes = this.isNew()
+      ? this.attributes
+      : _.pick(this.attributes, this.idAttribute)
+
+    return this._doRefresh(attributes, options);
+  },
+
+  // Fetch a model based on the currently set attributes, returning a model to
+  // the callback, along with any options.  Returns a deferred promise through
+  // the `Bookshelf.Sync`.  If `{require: true}` is set as an option, the fetch
+  // is considered a failure if the model comes up blank.
+  fetch: function(options) {
+
+    // Fetch uses all set attributes.
+    return this._doRefresh(this.attributes, options);
+  },
+
+  _doRefresh: Promise.method(function(attributes, options) {
     options = options ? _.clone(options) : {};
 
     // Run the `first` call on the `sync` object to fetch a single model.
     return this.sync(options)
-      .first()
+      .first(attributes)
       .bind(this)
 
       // Jump the rest of the chain if the response doesn't exist...

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -31,26 +31,29 @@ _.extend(Sync.prototype, {
   },
 
   // Select the first item from the database - only used by models.
-  first: Promise.method(function() {
+  first: Promise.method(function(attributes) {
 
-    // Only used for by models.
-    var model = this.syncing;
+    var model = this.syncing,
+        query = this.query,
+        whereAttributes,
+        formatted;
 
-    // If this is new, we use all its attributes. Otherwise we just grab the
-    // primary key.
-    //
-    // Note that we'll never use a JSON object for a search, because even
+    // We'll never use an JSON object for a search, because even
     // PostgreSQL, which has JSON type columns, does not support the `=`
     // operator.
-    var attributes = model.isNew()
-      ? _.omit(model.attributes, _.isObject)
-      : _.pick(model.attributes, model.idAttribute);
+    //
+    // NOTE: `_.omit` returns an empty object, even if attributes are null.
+    whereAttributes = _.omit(attributes, _.isPlainObject);
 
-    // Format and prefix attributes.
-    var prefixed = this.prefixFields(model.format(attributes));
+    if (!_.isEmpty(whereAttributes)) {
 
-    // Constrain query by search, and limit to a single result.
-    this.query.where(prefixed).limit(1);
+      // Format and prefix attributes.
+      formatted = this.prefixFields(model.format(whereAttributes));
+      query.where(formatted);
+    }
+
+    // Limit to a single result.
+    query.limit(1);
 
     return this.select();
   }),

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -32,9 +32,26 @@ _.extend(Sync.prototype, {
 
   // Select the first item from the database - only used by models.
   first: Promise.method(function() {
-    this.query.where(this.prefixFields(this.syncing.format(
-      _.extend(Object.create(null), this.syncing.attributes)
-    ))).limit(1);
+
+    // Only used for by models.
+    var model = this.syncing;
+
+    // If this is new, we use all its attributes. Otherwise we just grab the
+    // primary key.
+    //
+    // Note that we'll never use a JSON object for a search, because even
+    // PostgreSQL, which has JSON type columns, does not support the `=`
+    // operator.
+    var attributes = model.isNew()
+      ? _.omit(model.attributes, _.isObject)
+      : _.pick(model.attributes, model.idAttribute);
+
+    // Format and prefix attributes.
+    var prefixed = this.prefixFields(model.format(attributes));
+
+    // Constrain query by search, and limit to a single result.
+    this.query.where(prefixed).limit(1);
+
     return this.select();
   }),
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -30,9 +30,12 @@ module.exports = function(Bookshelf) {
   });
 
   _.each([MySQL, PostgreSQL, SQLite3], function(bookshelf) {
-    describe('Dialect: ' + bookshelf.knex.client.dialect, function() {
 
-      var dialect = this.dialect = bookshelf.knex.client.dialect;
+    var dialect = bookshelf.knex.client.dialect;
+
+    describe('Dialect: ' + dialect, function() {
+
+      this.dialect = dialect;
 
       before(function() {
         return require('./integration/helpers/migration')(bookshelf).then(function() {
@@ -43,10 +46,8 @@ module.exports = function(Bookshelf) {
       // Only testing this against mysql for now, just so the toString is reliable...
       if (dialect === 'mysql') {
         require('./integration/relation')(bookshelf);
-      } else if (dialect === 'postgresql') {
-        require('./integration/json')(bookshelf);
       }
-
+      
       require('./integration/model')(bookshelf);
       require('./integration/collection')(bookshelf);
       require('./integration/relations')(bookshelf);
@@ -54,6 +55,7 @@ module.exports = function(Bookshelf) {
       require('./integration/plugins/virtuals')(bookshelf);
       require('./integration/plugins/visibility')(bookshelf);
       require('./integration/plugins/registry')(bookshelf);
+      require('./integration/json')(bookshelf);
     });
 
   });

--- a/test/integration.js
+++ b/test/integration.js
@@ -32,17 +32,19 @@ module.exports = function(Bookshelf) {
   _.each([MySQL, PostgreSQL, SQLite3], function(bookshelf) {
     describe('Dialect: ' + bookshelf.knex.client.dialect, function() {
 
+      var dialect = this.dialect = bookshelf.knex.client.dialect;
+
       before(function() {
         return require('./integration/helpers/migration')(bookshelf).then(function() {
            return require('./integration/helpers/inserts')(bookshelf);
         });
       });
 
-      this.dialect = bookshelf.knex.client.dialect;
-
       // Only testing this against mysql for now, just so the toString is reliable...
-      if (bookshelf.knex.client.dialect === 'mysql') {
+      if (dialect === 'mysql') {
         require('./integration/relation')(bookshelf);
+      } else if (dialect === 'postgresql') {
+        require('./integration/json')(bookshelf);
       }
 
       require('./integration/model')(bookshelf);

--- a/test/integration.js
+++ b/test/integration.js
@@ -46,6 +46,8 @@ module.exports = function(Bookshelf) {
       // Only testing this against mysql for now, just so the toString is reliable...
       if (dialect === 'mysql') {
         require('./integration/relation')(bookshelf);
+      } else if (dialect === 'postgresql') {
+        require('./integration/json')(bookshelf);
       }
       
       require('./integration/model')(bookshelf);
@@ -55,7 +57,6 @@ module.exports = function(Bookshelf) {
       require('./integration/plugins/virtuals')(bookshelf);
       require('./integration/plugins/visibility')(bookshelf);
       require('./integration/plugins/registry')(bookshelf);
-      require('./integration/json')(bookshelf);
     });
 
   });

--- a/test/integration/helpers/json/inserts.js
+++ b/test/integration/helpers/json/inserts.js
@@ -1,0 +1,38 @@
+var Promise = global.testPromise;
+var _       = require('lodash');
+
+module.exports = function(bookshelf) {
+
+  var knex = bookshelf.knex;
+
+  return Promise.all([
+
+    knex('units').insert([{
+      id: 0,
+      name: 'tank'
+    }]),
+
+    knex('commands').insert([{
+      id: 0,
+      type: 'move',
+      unit_id: 1,
+      info: {
+        target: {
+          x: 5,
+          y: 10
+        }
+      }
+    }, {
+      id: 1,
+      unit_id: 1,
+      type: 'attack',
+      info: {
+        weapon: 'cannon',
+        target: {
+          x: 2,
+          y: 2
+        }
+      }
+    }])
+  ]);
+};

--- a/test/integration/helpers/json/migration.js
+++ b/test/integration/helpers/json/migration.js
@@ -1,0 +1,29 @@
+var _ = require('lodash');
+var Promise = global.testPromise;
+
+var drops = [
+  'units', 'commands'
+];
+
+module.exports = function(bookshelf) {
+
+  var schema = bookshelf.knex.schema;
+
+  return Promise.all(_.map(drops, function(val) {
+    return schema.dropTableIfExists(val);
+  }))
+  .then(function() {
+
+    return schema.createTable('units', function(table) {
+      table.increments('id');
+      table.string('name');
+    })
+    .createTable('commands', function(table) {
+      table.increments('id');
+      table.integer('unit_id').notNullable();
+      table.string('type');
+      table.json('info');
+    })
+  });
+
+};

--- a/test/integration/helpers/json/objects.js
+++ b/test/integration/helpers/json/objects.js
@@ -1,0 +1,27 @@
+// Models used for PostgreSQL jsonb type.
+module.exports = function(Bookshelf) {
+
+  var _ = require('lodash');
+
+  var Unit = Bookshelf.Model.extend({
+    tableName: 'units',
+    commands: function() {
+      return this.hasMany(Command);
+    }
+  });
+
+  var Command = Bookshelf.Model.extend({
+    tableName: 'commands',
+    unit: function() {
+      return this.belongsTo(Unit);
+    }
+  });
+
+  return {
+    Models: {
+      Unit: Unit,
+      Command: Command
+    }
+  };
+
+};

--- a/test/integration/helpers/json/supported.js
+++ b/test/integration/helpers/json/supported.js
@@ -1,0 +1,14 @@
+var Promise = require('bluebird');
+var semver = require('semver');
+
+module.exports = Promise.method(function (bookshelf) {
+  var knex = bookshelf.knex;
+  if (knex.client.dialect === 'postgresql') {
+    return knex.raw('show server_version')
+      .then(function(result) {
+        var version = result.rows[0].server_version;
+        return semver.gt(version, '9.2.0');
+      })
+  }
+  return false;
+});

--- a/test/integration/json.js
+++ b/test/integration/json.js
@@ -1,14 +1,29 @@
-var _    = require('lodash');
-
-var Promise   = global.testPromise;
+var _       = require('lodash');
+var Promise = global.testPromise;
 
 
 module.exports = function(bookshelf) {
 
+  var isJsonSupported;
+
+  function checkJson() {
+    if (!isJsonSupported) {
+      console.log('Test skipped... JSON columns not supported');
+    }
+    return isJsonSupported;
+  }
+
   before(function() {
-    return require('./helpers/json/migration')(bookshelf).then(function() {
+    return require('./helpers/json/supported')(bookshelf).then(function(supported) {
+      isJsonSupported = supported;
+      if (!isJsonSupported) {
+        throw null;
+      }
+      return require('./helpers/json/migration')(bookshelf)
+    }).then(function() {
        return require('./helpers/json/inserts')(bookshelf);
-    });
+    }).then(function() {
+    }).catch(_.isNull, _.noop);
   });
 
   describe('JSON support', function() {
@@ -17,7 +32,10 @@ module.exports = function(bookshelf) {
     var Tank = Models.Tank;
     var Command = Models.Command;
 
+
     it('can `fetch` a model with a JSON column', function() {
+      if (!checkJson()) return;
+
       return Command.forge({id: 0}).fetch()
         .then(function(command) {
           expect(command.attributes).to.eql({
@@ -35,6 +53,8 @@ module.exports = function(bookshelf) {
     });
 
     it('Trying to fetch a model automatically excludes JSON column', function() {
+      if (!checkJson()) return;
+
       return Command.forge({unit_id: 1, type: 'attack', info: {test: 'blah'}}).fetch()
         .then(function(command) {
           expect(command.attributes).to.eql({

--- a/test/integration/json.js
+++ b/test/integration/json.js
@@ -6,24 +6,26 @@ module.exports = function(bookshelf) {
 
   var isJsonSupported;
 
-  function checkJson() {
+  function checkResponse(actual, expected) {
+    // Knex will store strings if client does not support JSON.
     if (!isJsonSupported) {
-      console.log('Test skipped... JSON columns not supported');
+      expected = _.mapValues(expected, function(value) {
+        if (_.isObject(value)) {
+          return JSON.stringify(value);
+        }
+        return value
+      });
     }
-    return isJsonSupported;
+    expect(actual).to.eql(expected);
   }
 
   before(function() {
     return require('./helpers/json/supported')(bookshelf).then(function(supported) {
       isJsonSupported = supported;
-      if (!isJsonSupported) {
-        throw null;
-      }
       return require('./helpers/json/migration')(bookshelf)
     }).then(function() {
        return require('./helpers/json/inserts')(bookshelf);
-    }).then(function() {
-    }).catch(_.isNull, _.noop);
+    });
   });
 
   describe('JSON support', function() {
@@ -34,11 +36,9 @@ module.exports = function(bookshelf) {
 
 
     it('can `fetch` a model with a JSON column', function() {
-      if (!checkJson()) return;
-
       return Command.forge({id: 0}).fetch()
         .then(function(command) {
-          expect(command.attributes).to.eql({
+          checkResponse(command.attributes, {
             id: 0,
             unit_id: 1,
             type: 'move',
@@ -53,11 +53,9 @@ module.exports = function(bookshelf) {
     });
 
     it('Trying to fetch a model automatically excludes JSON column', function() {
-      if (!checkJson()) return;
-
       return Command.forge({unit_id: 1, type: 'attack', info: {test: 'blah'}}).fetch()
         .then(function(command) {
-          expect(command.attributes).to.eql({
+          checkResponse(command.attributes, {
             id: 1,
             unit_id: 1,
             type: 'attack',

--- a/test/integration/json.js
+++ b/test/integration/json.js
@@ -1,0 +1,55 @@
+var _    = require('lodash');
+
+var Promise   = global.testPromise;
+
+
+module.exports = function(bookshelf) {
+
+  before(function() {
+    return require('./helpers/json/migration')(bookshelf).then(function() {
+       return require('./helpers/json/inserts')(bookshelf);
+    });
+  });
+
+  describe('JSON support', function() {
+    var Models = require('./helpers/json/objects')(bookshelf).Models;
+
+    var Tank = Models.Tank;
+    var Command = Models.Command;
+
+    it('can `fetch` a model with a JSON column', function() {
+      return Command.forge({id: 0}).fetch()
+        .then(function(command) {
+          expect(command.attributes).to.eql({
+            id: 0,
+            unit_id: 1,
+            type: 'move',
+            info: {
+              target: {
+                x: 5,
+                y: 10
+              }
+            }
+          });
+        });
+    });
+
+    it('Trying to fetch a model automatically excludes JSON column', function() {
+      return Command.forge({unit_id: 1, type: 'attack', info: {test: 'blah'}}).fetch()
+        .then(function(command) {
+          expect(command.attributes).to.eql({
+            id: 1,
+            unit_id: 1,
+            type: 'attack',
+            info: {
+              weapon: 'cannon',
+              target: {
+                x: 2,
+                y: 2
+              }
+            }
+          });
+        });
+    });
+  });
+};

--- a/test/unit/sql/sync.js
+++ b/test/unit/sql/sync.js
@@ -56,6 +56,10 @@ module.exports = function() {
 
       it('should run after format', function() {
 
+        var attributes = {
+          'Some': 'column',
+          'Another': 'column'
+        };
         var sync = new Sync(_.extend(stubSync(), {
           format: function(attrs) {
             var data = {};
@@ -63,10 +67,6 @@ module.exports = function() {
               data[key.toLowerCase()] = attrs[key];
             }
             return data;
-          },
-          attributes: {
-            'Some': 'column',
-            'Another': 'column'
           }
         }));
         sync.select = function() {
@@ -75,7 +75,7 @@ module.exports = function() {
             "testtable.another": "column"
           }]);
         };
-        return sync.first();
+        return sync.first(attributes);
 
       });
 

--- a/test/unit/sql/sync.js
+++ b/test/unit/sql/sync.js
@@ -20,6 +20,9 @@ module.exports = function() {
       };
       return {
         tableName: 'testtable',
+        isNew: function() {
+          return true
+        },
         queryData: qd,
         query: function() {
           return {


### PR DESCRIPTION
Adds new method called `refresh`, which behaves similarly to `fetch`, but will fetch by ID attribute alone if possible (allowing for updating changed attributes, and predictable fetching on indexed columns).

Addresses other unexpected behaviour in `fetch`, such as trying to use json columns in `where` clauses (not valid).

See #796, #550, #778.