### PR TITLE
Fix 807

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -108,37 +108,45 @@ _.extend(Sync.prototype, {
   // the promise is resolved. Any `success` handler passed in the
   // options will be called - used by both models & collections.
   select: Promise.method(function () {
+    var _this = this;
+
     var knex = this.query,
         options = this.options,
         relatedData = this.syncing.relatedData,
-        columnsInQuery = _.some(knex._statements, { grouping: 'columns' }),
+        queryContainsColumns,
         columns;
 
-    if (!relatedData) {
-      columns = options.columns;
-      // Call the function, if one exists, to constrain the eager loaded query.
-      if (options._beforeFn) options._beforeFn.call(knex, knex);
-      if (!_.isArray(columns)) {
-        columns = columns ? [columns] :
-        // if columns have been selected in a query closure, use them.
-        // any user who does this is responsible for prefixing each
-        // selected column with the correct table name. this will also
-        // break withRelated queries if the dependent fkey fields are not
-        // manually included. this is a temporary hack which will be
-        // replaced by an upcoming rewrite.
-        columnsInQuery ? [] : [_.result(this.syncing, 'tableName') + '.*'];
+    // Check if any `select` style statements have been called with column
+    // specifications. This could include `distinct()` with no arguments, which
+    // does not affect inform the columns returned.
+    queryContainsColumns = _(knex._statements).where({ grouping: 'columns' }).some('value.length');
+
+    return Promise.resolve(this.constrain()).tap(function () {
+
+      // If this is a relation, apply the appropriate constraints.
+      if (relatedData) {
+        relatedData.selectConstraints(knex, options);
+      } else {
+
+        // Call the function, if one exists, to constrain the eager loaded query.
+        if (options._beforeFn) options._beforeFn.call(knex, knex);
+
+        if (options.columns) {
+
+          // Normalize single column name into array.
+          columns = _.isArray(options.columns) ? options.columns : [options.columns];
+        } else if (!queryContainsColumns) {
+
+          // If columns have already been selected via the `query` method
+          // we will use them. Otherwise, select all columns in this table.
+          columns = [_.result(_this.syncing, 'tableName') + '.*'];
+        }
       }
-    }
 
-    // Set the query builder on the options, in-case we need to
-    // access in the `fetching` event handlers.
-    options.query = knex;
-
-    return Promise.bind(this).then(function () {
-      return this.constrain();
-    }).then(function () {
-      if (relatedData) relatedData.selectConstraints(knex, options);
-      return this.syncing.triggerThen('fetching', this.syncing, columns, options);
+      // Set the query builder on the options, for access in the `fetching`
+      // event handlers.
+      options.query = knex;
+      return _this.syncing.triggerThen('fetching', _this.syncing, columns, options);
     }).then(function () {
       return knex.select(columns);
     });

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -322,6 +322,7 @@ module.exports = function(bookshelf) {
     describe('fetch', function() {
 
       var Site = Models.Site;
+      var Author = Models.Author;
 
       it('issues a first (get one) to Knex, triggering a fetched event, returning a promise', function() {
         var count = 0;
@@ -362,6 +363,32 @@ module.exports = function(bookshelf) {
           qb.join('authors', 'authors.site_id', '=', 'sites.id');
         });
         return model.fetch()
+      });
+
+      it('allows specification of select columns as an `options` argument', function () {
+        var model = new Author({id: 1}).fetch({columns: ['first_name']})
+          .then(function (model) {
+            deepEqual(model.toJSON(), {id: 1, first_name: 'Tim'});
+          });
+      });
+
+      it('allows specification of select columns in query callback', function () {
+        var model = new Author({id: 1}).query('select','first_name').fetch()
+          .then(function (model) {
+            deepEqual(model.toJSON(), {id: 1, first_name: 'Tim'});
+          });
+      });
+
+      it('will still select default columns if `distinct` is called without columns - #807', function () {
+        var model = new Author({id: 1}).query('distinct').fetch()
+          .then(function (model) {
+            deepEqual(model.toJSON(), {
+              id: 1,
+              first_name: 'Tim',
+              last_name: 'Griesser',
+              site_id: 1
+            });
+          });
       });
 
     });


### PR DESCRIPTION
Prevent `distinct`, `select` etc. from overriding default column fetch columns when no column arguments are specified.