### PR TITLE
fix error handling in /base/eager.js

### DIFF
--- a/lib/base/eager.js
+++ b/lib/base/eager.js
@@ -48,9 +48,11 @@ _.extend(EagerBase.prototype, {
 
       // Only allow one of a certain nested type per-level.
       if (handled[relationName]) continue;
-
+      
+      if (target[relationName]===undefined) throw new Error(relationName + ' is not defined on the model.');
+      
       relation = target[relationName]();
-
+      
       if (!relation) throw new Error(relationName + ' is not defined on the model.');
 
       handled[relationName] = relation;


### PR DESCRIPTION
we need to check if relationName key exists on target ,
because if it is undefined , library generate error because of function call on undefined() .