### PR TITLE
Fix typo on line 1074 of src_model.js.html

### DIFF
--- a/docs/src_model.js.html
+++ b/docs/src_model.js.html
@@ -1071,7 +1071,7 @@ let BookshelfModel = ModelBase.extend({
         /**
          * Saved event.
          *
-         * Fired before after an `insert` or `update` query.
+         * Fired after an `insert` or `update` query.
          *
          * @event Model#saved
          * @param {Model}  model    The model firing the event.


### PR DESCRIPTION
Docs fix: text said the 'created' event fired 'before after' an insert/update query. Should just be 'fired after...'