### PR TITLE
Add equals sign to module.exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This initialization should likely only ever happen once in your application. As 
 ```js
 // In a file named something like bookshelf.js
 var knex = require('knex')(dbConfig);
-module.exports require('bookshelf')(knex);
+module.exports = require('bookshelf')(knex);
 
 // elsewhere, to use the bookshelf client:
 var bookshelf = require('./bookshelf');


### PR DESCRIPTION
Added a missing equals sign on line 56.  The example now shows ``` module.exports = require('bookshelf')(knex) ``` instead of ``` module.exports require('bookshelf')(knex) ``` .