### PR TITLE
Updated documentation for hasTimestamps

### DIFF
--- a/build/bookshelf.js
+++ b/build/bookshelf.js
@@ -164,7 +164,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	     * @param {string=}  options.tableName     Initial value for {@linkcode Model#tableName tableName}.
 	     * @param {boolean=} [options.hasTimestamps=false]
 	     *
-	     *   Initial value for {@linkcode Model#hasTimestamps hasTimestamps}.
+	     *   Initial value for {@linkcode Model#hasTimestamps hasTimestamps}. Can be an array to override default column names.
 	     *
 	     * @param {boolean} [options.parse=false]
 	     *
@@ -761,7 +761,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * @param {string=}  options.tableName     Initial value for {@link Model#tableName tableName}.
 	 * @param {boolean=} [options.hasTimestamps=false]
 	 *
-	 *   Initial value for {@link Model#hasTimestamps hasTimestamps}.
+	 *   Initial value for {@link Model#hasTimestamps hasTimestamps}. Can be an array to override default column names.
 	 *
 	 * @param {boolean} [options.parse=false]
 	 *

--- a/docs/src_base_model.js.html
+++ b/docs/src_base_model.js.html
@@ -472,12 +472,13 @@ ModelBase.prototype.saveMethod = function(options) {
  * @method
  * @description
  * Sets the timestamp attributes on the model, if {@link Model#hasTimestamps
- * hasTimestamps} is set to `true` or an array. Check if the model {@link
- * Model#isNew isNew} or if `{method: 'insert'}` is provided as an option and
- * set the `created_at` and `updated_at` attributes to the current date if it
- * is being inserted, and just the `updated_at` attribute if it's being updated.
- * This method may be overriden to use different column names or types for the
- * timestamps.
+ * hasTimestamps} is set to `true` or an array to override the default column names. 
+ * If an array is passed the first element will be the 'created' column name and the second 
+ * element will be the 'updated' column name. Check if the model {@link Model#isNew isNew} or 
+ * if `{method: 'insert'}` is provided as an option and set the `created_at` and `updated_at` 
+ * attributes to the current date if it is being inserted, and just the `updated_at` 
+ * attribute if it's being updated.
+ *
  *
  * @param {Object=} options
  * @param {string} [options.method="update"]

--- a/docs/src_bookshelf.js.html
+++ b/docs/src_bookshelf.js.html
@@ -137,7 +137,7 @@ function Bookshelf(knex) {
      * @param {string=}  options.tableName     Initial value for {@linkcode Model#tableName tableName}.
      * @param {boolean=} [options.hasTimestamps=false]
      *
-     *   Initial value for {@linkcode Model#hasTimestamps hasTimestamps}.
+     *   Initial value for {@linkcode Model#hasTimestamps hasTimestamps}. Can be an array to override default column names.
      *
      * @param {boolean} [options.parse=false]
      *

--- a/docs/src_model.js.html
+++ b/docs/src_model.js.html
@@ -126,7 +126,7 @@ import Promise from './base/promise';
  * @param {string=}  options.tableName     Initial value for {@link Model#tableName tableName}.
  * @param {boolean=} [options.hasTimestamps=false]
  *
- *   Initial value for {@link Model#hasTimestamps hasTimestamps}.
+ *   Initial value for {@link Model#hasTimestamps hasTimestamps}.  Can be an array to override default column names.
  *
  * @param {boolean} [options.parse=false]
  *

--- a/lib/bookshelf.js
+++ b/lib/bookshelf.js
@@ -91,7 +91,7 @@ function Bookshelf(knex) {
      * @param {string=}  options.tableName     Initial value for {@linkcode Model#tableName tableName}.
      * @param {boolean=} [options.hasTimestamps=false]
      *
-     *   Initial value for {@linkcode Model#hasTimestamps hasTimestamps}.
+     *   Initial value for {@linkcode Model#hasTimestamps hasTimestamps}. Can be an array to override default column names.
      *
      * @param {boolean} [options.parse=false]
      *

--- a/lib/model.js
+++ b/lib/model.js
@@ -77,7 +77,7 @@ var _basePromise2 = _interopRequireDefault(_basePromise);
  * @param {string=}  options.tableName     Initial value for {@link Model#tableName tableName}.
  * @param {boolean=} [options.hasTimestamps=false]
  *
- *   Initial value for {@link Model#hasTimestamps hasTimestamps}.
+ *   Initial value for {@link Model#hasTimestamps hasTimestamps}. Can be an array to override default column names.
  *
  * @param {boolean} [options.parse=false]
  *

--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -63,7 +63,7 @@ function Bookshelf(knex) {
      * @param {string=}  options.tableName     Initial value for {@linkcode Model#tableName tableName}.
      * @param {boolean=} [options.hasTimestamps=false]
      *
-     *   Initial value for {@linkcode Model#hasTimestamps hasTimestamps}.
+     *   Initial value for {@linkcode Model#hasTimestamps hasTimestamps}. Can be an array to override default column names.
      *
      * @param {boolean} [options.parse=false]
      *

--- a/src/model.js
+++ b/src/model.js
@@ -52,7 +52,7 @@ import Promise from './base/promise';
  * @param {string=}  options.tableName     Initial value for {@link Model#tableName tableName}.
  * @param {boolean=} [options.hasTimestamps=false]
  *
- *   Initial value for {@link Model#hasTimestamps hasTimestamps}.
+ *   Initial value for {@link Model#hasTimestamps hasTimestamps}. Can be an array to override default column names.
  *
  * @param {boolean} [options.parse=false]
  *


### PR DESCRIPTION
It was not clear from the documentation that you could pass in an array
to override the ‘created_at’ and ‘updated_at’ column names.