### PR TITLE
Update some 0.8.1 version strings to latest

### DIFF
--- a/bookshelf.js
+++ b/bookshelf.js
@@ -5,7 +5,7 @@
  * For all details and documentation:
  * http://bookshelfjs.org
  *
- * version 0.8.1
+ * version 0.8.2
  *
  */
 module.exports = require('./lib/bookshelf')

--- a/build/bookshelf.js
+++ b/build/bookshelf.js
@@ -61,7 +61,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * For all details and documentation:
 	 * http://bookshelfjs.org
 	 *
-	 * version 0.8.1
+	 * version 0.8.2
 	 *
 	 */
 	module.exports = __webpack_require__(1)
@@ -128,7 +128,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 */
 	function Bookshelf(knex) {
 	  var bookshelf = {
-	    VERSION: '0.8.1'
+	    VERSION: '0.8.2'
 	  };
 
 	  var range = '>=0.6.10 <0.9.0';

--- a/docs/bookshelf.js.html
+++ b/docs/bookshelf.js.html
@@ -79,7 +79,7 @@
  * For all details and documentation:
  * http://bookshelfjs.org
  *
- * version 0.8.1
+ * version 0.8.2
  *
  */
 module.exports = require('./lib/bookshelf')

--- a/docs/src_bookshelf.js.html
+++ b/docs/src_bookshelf.js.html
@@ -100,7 +100,7 @@ import Errors from './errors';
  */
 function Bookshelf(knex) {
   let bookshelf = {
-    VERSION: '0.8.1'
+    VERSION: '0.8.2'
   };
 
   let range = '>=0.6.10 &lt;0.9.0';

--- a/lib/bookshelf.js
+++ b/lib/bookshelf.js
@@ -55,7 +55,7 @@ var _errors2 = _interopRequireDefault(_errors);
  */
 function Bookshelf(knex) {
   var bookshelf = {
-    VERSION: '0.8.1'
+    VERSION: '0.8.2'
   };
 
   var range = '>=0.6.10 <0.9.0';

--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -26,7 +26,7 @@ import Errors from './errors';
  */
 function Bookshelf(knex) {
   let bookshelf = {
-    VERSION: '0.8.1'
+    VERSION: '0.8.2'
   };
 
   let range = '>=0.6.10 <0.9.0';


### PR DESCRIPTION
I found some version strings that are still set to 0.8.1, and it seems that these have snuck their way into current 0.8.2 documentation (see [here](http://bookshelfjs.org/docs/src_bookshelf.js.html#line28)). This fixes both comments and some documentation that has this incorrect version string.