### PR TITLE
Fix invalid changelog link for 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Change Log
 
-**0.8.2** — <small>_August 20, 2015_</small> — [Diff](https://github.com/tgriesser/bookshelf/compare/0.8.2...0.8.1)  
+**0.8.2** — <small>_August 20, 2015_</small> — [Diff](https://github.com/tgriesser/bookshelf/compare/0.8.1...0.8.2)  
 
 *   ES6/7: Move code base to `/src` — code is now compiled into `/lib` via [Babel](https://babeljs.io/).
 *   Add `collection.count`, `model.count` and `Model.count`.


### PR DESCRIPTION
In `CHANGELOG.md`, I found that the diff between 0.8.1 and 0.8.2 is improperly linked. It sets 0.8.2 as the base, which does not properly show the diff between the update to this new version. I've updated the link so it looks correct.