### PR TITLE
Fix missing error on undefined non-first withRelated relations.

### DIFF
--- a/lib/base/eager.js
+++ b/lib/base/eager.js
@@ -22,7 +22,7 @@ _.extend(EagerBase.prototype, {
   // This helper function is used internally to determine which relations
   // are necessary for fetching based on the `model.load` or `withRelated` option.
   fetch: Promise.method(function (options) {
-    var relationName, related, relation;
+    var relationName, related;
     var target = this.target;
     var handled = this.handled = {};
     var withRelated = this.prepWithRelated(options.withRelated);
@@ -34,6 +34,7 @@ _.extend(EagerBase.prototype, {
     // Eager load each of the `withRelated` relation item, splitting on '.'
     // which indicates a nested eager load.
     for (var key in withRelated) {
+      var relation = null;
 
       related = key.split('.');
       relationName = related[0];

--- a/lib/base/eager.js
+++ b/lib/base/eager.js
@@ -34,8 +34,6 @@ _.extend(EagerBase.prototype, {
     // Eager load each of the `withRelated` relation item, splitting on '.'
     // which indicates a nested eager load.
     for (var key in withRelated) {
-      var relation = null;
-
       related = key.split('.');
       relationName = related[0];
 
@@ -50,11 +48,11 @@ _.extend(EagerBase.prototype, {
       // Only allow one of a certain nested type per-level.
       if (handled[relationName]) continue;
 
-      if (_.isFunction(target[relationName])) {
-        relation = target[relationName]();
+      if (!_.isFunction(target[relationName])) {
+        throw new Error(relationName + ' is not defined on the model.');
       }
 
-      if (!relation) throw new Error(relationName + ' is not defined on the model.');
+      var relation = target[relationName]();
 
       handled[relationName] = relation;
     }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -158,7 +158,7 @@ var BookshelfCollection = _baseCollection2['default'].extend({
    * @example
    *
    * // select count(*) from shareholders where company_id = 1 and share &gt; 0.1;
-   * Company.forge(({id:1})
+   * Company.forge({id:1})
    *   .shareholders()
    *   .query('where', 'share', '>', '0.1')
    *   .count()

--- a/lib/model.js
+++ b/lib/model.js
@@ -83,14 +83,14 @@ var _basePromise2 = _interopRequireDefault(_basePromise);
  *
  *   Convert attributes by {@link Model#parse parse} before being {@link
  *   Model#set set} on the model.
- *   
+ *
  */
 var BookshelfModel = _baseModel2['default'].extend({
 
   /**
    * The `hasOne` relation specifies that this table has exactly one of another
    * type of object, specified by a foreign key in the other table.
-   * 
+   *
    *     let Record = bookshelf.Model.extend({
    *       tableName: 'health_records'
    *     });
@@ -105,7 +105,7 @@ var BookshelfModel = _baseModel2['default'].extend({
    *     // select * from `health_records` where `patient_id` = 1;
    *     new Patient({id: 1}).related('record').fetch().then(function(model) {
    *       ...
-   *     }); 
+   *     });
    *
    *     // alternatively, if you don't need the relation loaded on the patient's relations hash:
    *     new Patient({id: 1}).record().fetch().then(function(model) {
@@ -218,7 +218,7 @@ var BookshelfModel = _baseModel2['default'].extend({
    *     let Account = bookshelf.Model.extend({
    *       tableName: 'accounts'
    *     });
-   *     
+   *
    *     let User = bookshelf.Model.extend({
    *       tableName: 'users',
    *       allAccounts: function () {
@@ -562,10 +562,10 @@ var BookshelfModel = _baseModel2['default'].extend({
    * Model#attributes attributes} currently set on the model to form a `select`
    * query. 
    *
-   * A {@link Model#fetching "fetching"} event will be fired just before the
+   * A {@link Model#event:fetching "fetching"} event will be fired just before the
    * record is fetched; a good place to hook into for validation. {@link
-   * Model#fetched "fetched"} event will be fired when a record is successfully
-   * retrieved.
+   * Model#event:fetched "fetched"} event will be fired when a record is
+   * successfully retrieved.
    *
    * If you need to constrain the query
    * performed by fetch, you can call {@link Model#query query} before calling
@@ -584,27 +584,32 @@ var BookshelfModel = _baseModel2['default'].extend({
    * {@link Model#query query}, tapping into the {@link Knex} {@link
    * Knex#column column} method to specify which columns will be fetched._
    *
-   * The `withRelated` parameter may be specified to fetch the resource, along
-   * with any specified {@link Model#relations relations} named on the model. A
    * single property, or an array of properties can be specified as a value for
-   * the `withRelated` property. The results of these relation queries will be
-   * loaded into a {@link Model#relations relations} property on the model, may
-   * be retrieved with the {@link Model#related related} method, and will be
-   * serialized as properties on a {@link Model#toJSON toJSON} call unless
-   * `{shallow: true}` is passed.  
+   * the `withRelated` property. You can also execute callbacks on relations
+   * queries (eg. for sorting a relation). The results of these relation queries
+   * will be loaded into a {@link Model#relations relations} property on the
+   * model, may be retrieved with the {@link Model#related related} method, and
+   * will be serialized as properties on a {@link Model#toJSON toJSON} call
+   * unless `{shallow: true}` is passed.  
    *
    *     let Book = bookshelf.Model.extend({
    *       tableName: 'books',
    *       editions: function() {
    *         return this.hasMany(Edition);
    *       },
+   *       chapters: function{
+   *         return this.hasMany(Chapter);
+   *       },
    *       genre: function() {
    *         return this.belongsTo(Genre);
    *       }
    *     })
-   *     
+   *
    *     new Book({'ISBN-13': '9780440180296'}).fetch({
-   *       withRelated: ['genre', 'editions']
+   *       withRelated: [
+   *         'genre', 'editions',
+   *         { chapters: function(query) { query.orderBy('chapter_number'); }}
+   *       ]
    *     }).then(function(book) {
    *       console.log(book.related('genre').toJSON());
    *       console.log(book.related('editions').toJSON());
@@ -615,12 +620,15 @@ var BookshelfModel = _baseModel2['default'].extend({
    *
    * @param {Object=}  options - Hash of options.
    * @param {boolean=} [options.require=false]
-   *   If `true`, will reject the returned response with a {@link
-   *   Model.NotFoundError NotFoundError} if no result is found.
-   * @param {(string|string[])=} [options.columns='*']
-   *   Limit the number of columns fetched.
-   * @param {Transaction=} options.transacting
+   *   Reject the returned response with a {@link Model.NotFoundError
+   *   NotFoundError} if no results are empty.
+   * @param {string|string[]} [options.columns='*']
+   *   Specify columns to be retireved.
+   * @param {Transaction} [options.transacting]
    *  Optionally run the query in a transaction.
+   * @param {string|Object|mixed[]} [options.withRelated]
+   *  Relations to be retrieved with `Model` instance. Either one or more
+   *  relation names or objects mapping relation names to query callbacks.
    *
    * @fires Model#fetching
    * @fires Model#fetched
@@ -628,7 +636,8 @@ var BookshelfModel = _baseModel2['default'].extend({
    * @throws {Model.NotFoundError}
    *
    * @returns {Promise<Model|undefined>}
-   *  A promise resolving to the fetched {@link Model model} or `undefined` if none exists.
+   *  A promise resolving to the fetched {@link Model model} or `undefined` if
+   *  none exists.
    *
    */
   fetch: function fetch(options) {
@@ -656,8 +665,8 @@ var BookshelfModel = _baseModel2['default'].extend({
 
     // If the "withRelated" is specified, we also need to eager load all of the
     // data on the model, as a side-effect, before we ultimately jump into the
-    // next step of the model. Since the `columns` are only relevant to the current
-    // level, ensure those are omitted from the options.
+    // next step of the model. Since the `columns` are only relevant to the
+    // current level, ensure those are omitted from the options.
     .tap(function (response) {
       if (options.withRelated) {
         return this._handleEager(response, _lodash2['default'].omit(options, 'columns'));
@@ -669,10 +678,15 @@ var BookshelfModel = _baseModel2['default'].extend({
        * event handler for async behaviour.
        *
        * @event Model#fetched
-       * @param {Model}  model    The model firing the event.
-       * @param {Object} reponse  Knex query response.
-       * @param {Object} options  Options object passed to {@link Model#fetch fetch}.
+       * @param {Model} model
+       *   The model firing the event.
+       * @param {Object} reponse
+       *   Knex query response.
+       * @param {Object} options
+       *   Options object passed to {@link Model#fetch fetch}.
        * @returns {Promise}
+       *   If the handler returns a promise, `fetch` will wait for it to
+       *   be resolved.
        */
       return this.triggerThen('fetched', this, response, options);
     })['return'](this)['catch'](function (err) {
@@ -948,7 +962,7 @@ var BookshelfModel = _baseModel2['default'].extend({
        *
        * @event Model#saving
        * @param {Model}  model    The model firing the event.
-       * @param {Object} attrs    Model firing the event.
+       * @param {Object} attrs    Attributes that will be inserted or updated.
        * @param {Object} options  Options object passed to {@link Model#save save}.
        * @returns {Promise}
        */
@@ -962,7 +976,7 @@ var BookshelfModel = _baseModel2['default'].extend({
        *
        * @event Model#creating
        * @param {Model}  model    The model firing the event.
-       * @param {Object} attrs    Model firing the event.
+       * @param {Object} attrs    Attributes that will be inserted.
        * @param {Object} options  Options object passed to {@link Model#save save}.
        * @returns {Promise}
        */
@@ -976,7 +990,7 @@ var BookshelfModel = _baseModel2['default'].extend({
        *
        * @event Model#updating
        * @param {Model}  model    The model firing the event.
-       * @param {Object} attrs    Model firing the event.
+       * @param {Object} attrs    Attributes that will be updated.
        * @param {Object} options  Options object passed to {@link Model#save save}.
        * @returns {Promise}
        */

--- a/src/base/eager.js
+++ b/src/base/eager.js
@@ -32,8 +32,6 @@ _.extend(EagerBase.prototype, {
     // Eager load each of the `withRelated` relation item, splitting on '.'
     // which indicates a nested eager load.
     for (var key in withRelated) {
-      var relation = null;
-
       related = key.split('.');
       relationName = related[0];
 
@@ -48,11 +46,11 @@ _.extend(EagerBase.prototype, {
       // Only allow one of a certain nested type per-level.
       if (handled[relationName]) continue;
 
-      if (_.isFunction(target[relationName])){
-        relation = target[relationName]();
+      if (!_.isFunction(target[relationName])){
+        throw new Error(relationName + ' is not defined on the model.');
       }
 
-      if (!relation) throw new Error(relationName + ' is not defined on the model.');
+      const relation = target[relationName]();
 
       handled[relationName] = relation;
     }

--- a/src/base/eager.js
+++ b/src/base/eager.js
@@ -20,7 +20,7 @@ _.extend(EagerBase.prototype, {
   // This helper function is used internally to determine which relations
   // are necessary for fetching based on the `model.load` or `withRelated` option.
   fetch: Promise.method(function(options) {
-    var relationName, related, relation;
+    var relationName, related;
     var target      = this.target;
     var handled     = this.handled = {};
     var withRelated = this.prepWithRelated(options.withRelated);
@@ -32,6 +32,7 @@ _.extend(EagerBase.prototype, {
     // Eager load each of the `withRelated` relation item, splitting on '.'
     // which indicates a nested eager load.
     for (var key in withRelated) {
+      var relation = null;
 
       related = key.split('.');
       relationName = related[0];
@@ -46,7 +47,7 @@ _.extend(EagerBase.prototype, {
 
       // Only allow one of a certain nested type per-level.
       if (handled[relationName]) continue;
-      
+
       if (_.isFunction(target[relationName])){
         relation = target[relationName]();
       }
@@ -85,7 +86,7 @@ _.extend(EagerBase.prototype, {
       var related = withRelated[i];
       if (_.isString(related)) {
         obj[related] = noop
-      } else { 
+      } else {
         _.extend(obj, related);
       }
     }

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -127,6 +127,26 @@ module.exports = function(Bookshelf) {
           }).then(checkTest(this));
         });
 
+        it('throws an error on undefined first withRelated relations', function() {
+          return new Site({id: 1}).fetch({
+            withRelated: ['undefinedRelation']
+          }).then(function() {
+            throw new Error('This should not succeed');
+          }, function(err) {
+            expect(err.message).to.equal('undefinedRelation is not defined on the model.');
+          });
+        });
+
+        it('throws an error on undefined non-first withRelated relations', function() {
+          return new Site({id: 1}).fetch({
+            withRelated: ['authors', 'undefinedRelation']
+          }).then(function() {
+            throw new Error('This should not succeed');
+          }, function(err) {
+            expect(err.message).to.equal('undefinedRelation is not defined on the model.');
+          });
+        });
+
       });
 
       describe('Eager Loading - Collections', function() {


### PR DESCRIPTION
Fixed missing error when refering to undefined withRelated relations on fetch. Before this fix only the first withRelated relations will throw an error if it is undefined. If a non-first relation is undefined then that relation will actually refer to the previous relation in the withRelated array. See below example:

The following query:
```javascript
models.Game.forge({game_id: 5}).fetch({withRelated: ['genre', 'undefinedRelation']})
  .then(function (game) {
    console.log(game.toJSON());
  });
```

Returns the following even though 'undefinedRelation' is undefined on the Game model:

```javascript
{ game_id: 5,
  game_name: 'TEST-GAME',
  genre_id: 2,
  genre: { genre_id: 2, genre_name: 'TEST-GENRE', genre_shortname: 'TG' },
  undefinedRelation: { genre_id: 2, genre_name: 'TEST-GENRE', genre_shortname: 'TG' } }
```

The expected behaviour and the behaviour if 'undefinedRelation' is the first model is that an error is thrown with the message: "undefinedRelation is not defined on the model."

I got some unrelated changes in lib when building, not sure why.

The models can be seen below:
Game model:
```javascript
Game = esportBookshelf.Model.extend({
  tableName: 'game',
  idAttribute: 'game_id',

  genre: function () {
    return this.belongsTo('Genre', 'genre_id');
  }
});
```

Genre model:
```javascript
Genre = esportBookshelf.Model.extend({
  tableName: 'genre',
  idAttribute: 'genre_id',

  games: function () {
    return this.hasMany('Games', 'genre_id');
  }
});
```