### PR TITLE
Fix Virtuals Plugin to set key/value for patching which is set from v…

### DIFF
--- a/plugins/virtuals.js
+++ b/plugins/virtuals.js
@@ -76,15 +76,17 @@ module.exports = function (Bookshelf) {
         return proto.set.call(this, nonVirtuals, value, options);
       }
 
-      // Handle `"key", value` style arguments.
+      // Handle `"key", value` style arguments for virtual setter.
       if (setVirtual.call(this, value, key)) {
-        if (isPatching) {
-          this.patchAttributes[key] = value;
-        }
         return this;
-      } else if (isPatching) {
+      }
+
+      // Handle `"key", value` style assignment call to be added to patching
+      // attributes if set("key", value, ...) called from inside a virtual setter.
+      if (isPatching) {
         this.patchAttributes[key] = value;
       }
+      
       return proto.set.apply(this, arguments);
     },
 

--- a/plugins/virtuals.js
+++ b/plugins/virtuals.js
@@ -82,6 +82,8 @@ module.exports = function (Bookshelf) {
           this.patchAttributes[key] = value;
         }
         return this;
+      } else if (isPatching) {
+        this.patchAttributes[key] = value;
       }
       return proto.set.apply(this, arguments);
     },


### PR DESCRIPTION
…irtual setter.

In model definition:
```JavaScript
virtuals: {
    virtualAttribute: {
        set: function (value) {
            var modifiedValue = value + "Magic";
            this.set('originalAttribute', modifiedValue );
        }
    }
}
```
In program logic:
```JavaScript
modelInstance.save({virtualAttribute: "Virtual"}, {patch: true})
```

Without this fix the assignment of set operations inside virtual setters will not end up in `patchAttributes` variable.