### PR TITLE
Model#fetch returns `null` not `undefined`

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -213,8 +213,8 @@ var BookshelfCollection = _baseCollection2['default'].extend({
    *  Optionally run the query in a transaction.
    *
    * @throws {Model.NotFoundError}
-   * @returns {Promise<Model|undefined>}
-   *  A promise resolving to the fetched {@link Model model} or `undefined` if none exists.
+   * @returns {Promise<Model|null>}
+   *  A promise resolving to the fetched {@link Model model} or `null` if none exists.
    */
   fetchOne: _basePromise2['default'].method(function (options) {
     var model = new this.model();

--- a/lib/model.js
+++ b/lib/model.js
@@ -635,8 +635,8 @@ var BookshelfModel = _baseModel2['default'].extend({
    *
    * @throws {Model.NotFoundError}
    *
-   * @returns {Promise<Model|undefined>}
-   *  A promise resolving to the fetched {@link Model model} or `undefined` if
+   * @returns {Promise<Model|null>}
+   *  A promise resolving to the fetched {@link Model model} or `null` if
    *  none exists.
    *
    */

--- a/src/collection.js
+++ b/src/collection.js
@@ -192,8 +192,8 @@ let BookshelfCollection = CollectionBase.extend({
    *  Optionally run the query in a transaction.
    *
    * @throws {Model.NotFoundError}
-   * @returns {Promise<Model|undefined>}
-   *  A promise resolving to the fetched {@link Model model} or `undefined` if none exists.
+   * @returns {Promise<Model|null>}
+   *  A promise resolving to the fetched {@link Model model} or `null` if none exists.
    */
   fetchOne: Promise.method(function(options) {
     let model = new this.model();

--- a/src/model.js
+++ b/src/model.js
@@ -611,8 +611,8 @@ let BookshelfModel = ModelBase.extend({
    *
    * @throws {Model.NotFoundError}
    *
-   * @returns {Promise<Model|undefined>}
-   *  A promise resolving to the fetched {@link Model model} or `undefined` if
+   * @returns {Promise<Model|null>}
+   *  A promise resolving to the fetched {@link Model model} or `null` if
    *  none exists.
    *
    */

--- a/test/integration/collection.js
+++ b/test/integration/collection.js
@@ -155,6 +155,17 @@ module.exports = function(bookshelf) {
 
       });
 
+      it ('resolves to null if no model exists', function() {
+
+        return new Site({id:1})
+          .authors()
+          .query({where: {id: 40}})
+          .fetchOne()
+          .then(function(model) {
+            equal(model, null);
+          });
+      })
+
     });
 
     describe('sync', function() {

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -391,6 +391,13 @@ module.exports = function(bookshelf) {
           });
       });
 
+      it('resolves to null if no record exists', function() {
+        var model = new Author({id: 200}).fetch()
+          .then(function (model) {
+            equal(model, null);
+          });
+      });
+
     });
 
     describe('save', function() {


### PR DESCRIPTION
This is a [couple months late](https://github.com/tgriesser/bookshelf/issues/860#issuecomment-128099514), but at least there's a happy ending.

I've updated the documentation for Model#fetch to reflect that an unfetched model is a rejected promise that resolves to `null` instead of `undefined`. I've also added a test case that demonstrates this behavior.

fixes #860

**Edit**: I've updated my PR to include Collection#fetchOne documentation updates as well. I've also included a test for that case.