### PR TITLE
Fix Model.NoRowsUpdatedError documentation

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -1281,11 +1281,11 @@ let BookshelfModel = ModelBase.extend({
     child.NotFoundError = createError(this.NotFoundError)
 
     /**
-     * @class Model.NoRowsUpdated
+     * @class Model.NoRowsUpdatedError
      * @description
      *
-     *   Thrown when no records are found by {@link Model#fetch fetch} or
-     *   {@link Model#refresh} unless called with the `{require: false}` option.
+     *   Thrown when no records are saved by {@link Model#save save}
+     *   unless called with the `{require: false}` option.
      */
     child.NoRowsUpdatedError = createError(this.NoRowsUpdatedError)
 


### PR DESCRIPTION
Addresses #966/#967

This PR updates the `Model.NoRowsUpdatedError` documentation to reflect that `Model.save` makes use of this error instead of `Model.fetch` and `Model.refresh`. I have also updated the error name from `NoRowsUpdated` to `NoRowsUpdatedError` so it corresponds with the rest of the documentation and the actual error name that is thrown.