### PR TITLE
Fix documentation links

### DIFF
--- a/src/base/collection.js
+++ b/src/base/collection.js
@@ -107,7 +107,7 @@ CollectionBase.prototype.serialize = function(options) {
  * @description
  *
  * Called automatically by {@link
- * https://developer.mozilla.org/en-US/docs/Glossary/JSON#toJSON()_method
+ * https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior
  * `JSON.stringify`}. To customize serialization, override {@link
  * Collection#serialize serialize}.
  *

--- a/src/base/collection.js
+++ b/src/base/collection.js
@@ -82,13 +82,13 @@ CollectionBase.prototype.toString = function() {
  * @method
  * @description
  *
- * Return a raw array of the collection's {@link ModelBase#attributes
+ * Return a raw array of the collection's {@link Model#attributes
  * attributes} for JSON stringification. If the {@link Model models} have any
- * relations defined, this will also call {@link ModelBase ModelBase#toJSON} on
+ * relations defined, this will also call {@link Model#toJSON toJSON} on
  * each of the related objects, and include them on the object unless
  * `{shallow: true}` is passed as an option.
  *
- * `serialize` is called internally by {@link CollectionBase#toJSON toJSON}.
+ * `serialize` is called internally by {@link Collection#toJSON toJSON}.
  * Override this function if you want to customize its output.
 *
  * @param {Object=} options
@@ -109,9 +109,9 @@ CollectionBase.prototype.serialize = function(options) {
  * Called automatically by {@link
  * https://developer.mozilla.org/en-US/docs/Glossary/JSON#toJSON()_method
  * `JSON.stringify`}. To customize serialization, override {@link
- * CollectionBase#serialize serialize}.
+ * Collection#serialize serialize}.
  *
- * @param {options} Options passed to {@link CollectionBase#serialize}.
+ * @param {options} Options passed to {@link Collection#serialize}.
  */
 CollectionBase.prototype.toJSON = function(options) {
   return this.serialize(options)
@@ -362,7 +362,7 @@ CollectionBase.prototype.remove = function(models, options) {
  * any models as arguments will empty the entire collection.
  *
  * @param {Object[]|Model[]} Array of models or raw attribute objects.
- * @param {Object} options See {@link CollectionBase#add add}.
+ * @param {Object} options See {@link Collection#add add}.
  * @returns {Model[]} Array of models.
  */
 CollectionBase.prototype.reset = function(models, options) {
@@ -515,7 +515,7 @@ CollectionBase.prototype.pluck = function(attr) {
  * @method
  * @description
  * The `parse` method is called whenever a collection's data is returned in a
- * {@link CollectionBase#fetch fetch} call. The function is passed the raw
+ * {@link Collection#fetch fetch} call. The function is passed the raw
  * database `response` array, and should return an array to be set on the
  * collection. The default implementation is a no-op, simply passing through
  * the JSON response.

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -184,13 +184,13 @@ ModelBase.prototype.isNew = function() {
  * @method
  * @description
  *
- * Return a copy of the model's {@link ModelBase#attributes attributes} for JSON
+ * Return a copy of the model's {@link Model#attributes attributes} for JSON
  * stringification. If the {@link Model model} has any relations defined, this
- * will also call {@link ModelBase ModelBase#toJSON} on each of the related
+ * will also call {@link Model#toJSON toJSON} on each of the related
  * objects, and include them on the object unless `{shallow: true}` is
  * passed as an option.
  *
- * `serialize` is called internally by {@link ModelBase#toJSON toJSON}. Override
+ * `serialize` is called internally by {@link Model#toJSON toJSON}. Override
  * this function if you want to customize its output.
  *
  * @example
@@ -234,9 +234,9 @@ ModelBase.prototype.serialize = function(options) {
  * Called automatically by {@link
  * https://developer.mozilla.org/en-US/docs/Glossary/JSON#toJSON()_method
  * `JSON.stringify`}. To customize serialization, override {@link
- * BaseModel#serialize serialize}.
+ * Model#serialize serialize}.
  *
- * @param {Object=} options Options passed to {@link BaseModel#serialize}.
+ * @param {Object=} options Options passed to {@link Model#serialize}.
  */
 ModelBase.prototype.toJSON = function(options) {
   return this.serialize(options)
@@ -278,8 +278,8 @@ ModelBase.prototype.has = function(attr) {
  *
  * The parse method is called whenever a {@link Model model}'s data is returned
  * in a {@link Model#fetch fetch} call. The function is passed the raw database
- * response object, and should return the {@link ModelBase#attributes
- * attributes} hash to be {@link ModelBase#set set} on the model. The default
+ * response object, and should return the {@link Model#attributes
+ * attributes} hash to be {@link Model#set set} on the model. The default
  * implementation is a no-op, simply passing through the JSON response.
  * Override this if you need to format the database responses - for example
  * calling {@link
@@ -377,7 +377,7 @@ ModelBase.prototype.related = function(name) {
  * @method
  * @description
  * Returns a new instance of the model with identical {@link
- * ModelBase#attributes attributes}, including any relations from the cloned
+ * Model#attributes attributes}, including any relations from the cloned
  * model.
  *
  * @returns {Model} Cloned instance of this model.

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -232,7 +232,7 @@ ModelBase.prototype.serialize = function(options) {
  * @description
  *
  * Called automatically by {@link
- * https://developer.mozilla.org/en-US/docs/Glossary/JSON#toJSON()_method
+ * https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior
  * `JSON.stringify`}. To customize serialization, override {@link
  * Model#serialize serialize}.
  *

--- a/src/model.js
+++ b/src/model.js
@@ -97,7 +97,7 @@ let BookshelfModel = ModelBase.extend({
    *
    *   ForeignKey in the `Target` model. By default, the `foreignKey` is assumed to
    *   be the singular form of this model's {@link Model#tableName tableName},
-   *   followed by `_id` / `_{{{@link ModelBase#idAttribute idAttribute}}}`.
+   *   followed by `_id` / `_{{{@link Model#idAttribute idAttribute}}}`.
    *
    * @returns {Model}
    */
@@ -132,7 +132,7 @@ let BookshelfModel = ModelBase.extend({
    *
    *   ForeignKey in the `Target` model. By default, the foreignKey is assumed to
    *   be the singular form of this model's tableName, followed by `_id` /
-   *   `_{{{@link ModelBase#idAttribute idAttribute}}}`.
+   *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
    * @returns {Collection}
    */
@@ -175,7 +175,7 @@ let BookshelfModel = ModelBase.extend({
    *
    *   ForeignKey in this model. By default, the foreignKey is assumed to
    *   be the singular form of the `Target` model's tableName, followed by `_id` /
-   *   `_{{{@link ModelBase#idAttribute idAttribute}}}`.
+   *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
    * @returns {Model}
    */
@@ -209,7 +209,7 @@ let BookshelfModel = ModelBase.extend({
    *
    *  The default key names in the joining table are the singular versions of the
    *  model table names, followed by `_id` /
-   *  _{{{@link ModelBase#idAttribute idAttribute}}}. So in the above case, the
+   *  _{{{@link Model#idAttribute idAttribute}}}. So in the above case, the
    *  columns in the joining table
    *  would be `user_id`, `account_id`, and `access`, which is used as an
    *  example of how dynamic relations can be formed using different contexts.
@@ -265,13 +265,13 @@ let BookshelfModel = ModelBase.extend({
    *
    *   Foreign key in this model. By default, the `foreignKey` is assumed to
    *   be the singular form of the `Target` model's tableName, followed by `_id` /
-   *   `_{{{@link ModelBase#idAttribute idAttribute}}}`.
+   *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
    * @param {string=} otherKey
    *
    *   Foreign key in the `Target` model. By default, the `otherKey` is assumed to
    *   be the singular form of this model's tableName, followed by `_id` /
-   *   `_{{{@link ModelBase#idAttribute idAttribute}}}`.
+   *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
    * @returns {Collection}
    */
@@ -494,13 +494,13 @@ let BookshelfModel = ModelBase.extend({
    *
    *   Foreign key in this model. By default, the `foreignKey` is assumed to
    *   be the singular form of the `Target` model's tableName, followed by `_id` /
-   *   `_{{{@link ModelBase#idAttribute idAttribute}}}`.
+   *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
    * @param {string=} otherKey
    *
    *   Foreign key in the `Interim` model. By default, the `otherKey` is assumed to
    *   be the singular form of this model's tableName, followed by `_id` /
-   *   `_{{{@link ModelBase#idAttribute idAttribute}}}`.
+   *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
    * @returns {Collection}
    */
@@ -826,7 +826,7 @@ let BookshelfModel = ModelBase.extend({
    * `save` is used to perform either an insert or update query using the
    * model's set {@link Model#attributes attributes}.
    *
-   * If the model {@link ModelBase#isNew isNew}, any {@link Model#defaults defaults}
+   * If the model {@link Model#isNew isNew}, any {@link Model#defaults defaults}
    * will be set and an `insert` query will be performed. Otherwise it will
    * `update` the record with a corresponding ID. This behaviour can be overriden
    * with the `method` option.
@@ -1049,7 +1049,7 @@ let BookshelfModel = ModelBase.extend({
 
   /**
    * `destroy` performs a `delete` on the model, using the model's {@link
-   * ModelBase#idAttribute idAttribute} to constrain the query.
+   * Model#idAttribute idAttribute} to constrain the query.
    *
    * A {@link Model#destroying "destroying"} event is triggered on the model before being
    * destroyed. To prevent destroying the model (with validation, etc.), throwing an error


### PR DESCRIPTION
Example: http://bookshelfjs.org/#Model-instance-destroy _"using the model's [idAttribute](http://bookshelfjs.org/#ModelBase-instance-idAttribute) to constrain the query"_
The _idAttribute_ link does not work, it should be http://bookshelfjs.org/#Model-instance-idAttribute instead.

=> All _ModelBase_ links don't work. If they are replaced by _Model_ they work: I don't know if this is the correct fix so think twice before merging this :)