### PR TITLE
Adds documentation for argument to Model#related()

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -366,6 +366,7 @@ ModelBase.prototype.format = function(attrs) {
  *   }
  * });
  *
+ * @param name {string} The name of the relation to retrieve.
  * @returns {Model|Collection|undefined} The specified relation as defined by a
  *   method on the model, or undefined if it does not exist.
  */


### PR DESCRIPTION
The documentation for Model#related() was missing the method's sole argument.