### PR TITLE
Remove Collection#keys() method from documentation

### DIFF
--- a/src/base/collection.js
+++ b/src/base/collection.js
@@ -548,10 +548,6 @@ CollectionBase.prototype._reset = function() {
 };
 
 /**
- * @method CollectionBase#keys
- * @see http://lodash.com/docs/#keys
- */
-/**
  * @method CollectionBase#forEach
  * @see http://lodash.com/docs/#forEach
  */


### PR DESCRIPTION
Fixes #994, assuming @ricardograca is correct that `Collection` should not have a `keys()` method.