### PR TITLE
Removes default value for `method` option of `Model#timestamp` documentation

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -432,7 +432,7 @@ ModelBase.prototype.saveMethod = function({ method = null, patch = false } = {})
  * timestamps.
  *
  * @param {Object=} options
- * @param {string} [options.method="update"]
+ * @param {string} [options.method]
  *   Either `'insert'` or `'update'`. Specify what kind of save the attribute
  *   update is for.
  *


### PR DESCRIPTION
The `method` option doesn't have a default value, per se.
Rather, if `method` is omitted, `Model#isNew` is used to choose whether method is `"update"` or `"insert"`