### PR TITLE
Fixes `Model#fetchAll`, `Collection.EmptyError`, and `Model.NotFoundError` documentation

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -369,8 +369,9 @@ const BookshelfCollection = CollectionBase.extend({
     /**
      * @class Collection.EmptyError
      * @description
-     *   Thrown when no records are found by {@link Collection#fetch fetch} or {@link Model#fetchAll},
-     *   when called with the `{require: true}` option.
+     *   Thrown when no records are found by {@link Collection#fetch fetch},
+     *   {@link Model#fetchAll}, or {@link Model.fetchAll} when called with
+     *   the `{require: true}` option.
      */
     child.EmptyError = createError(this.EmptyError)
   }

--- a/src/collection.js
+++ b/src/collection.js
@@ -367,9 +367,9 @@ const BookshelfCollection = CollectionBase.extend({
 
   extended: function(child) {
     /**
-     * @class Collection.NotFoundError
+     * @class Collection.EmptyError
      * @description
-     *   Thrown when no records are found by {@link Collection#fetch fetch},
+     *   Thrown when no records are found by {@link Collection#fetch fetch} or {@link Model#fetchAll},
      *   when called with the `{require: true}` option.
      */
     child.EmptyError = createError(this.EmptyError)

--- a/src/model.js
+++ b/src/model.js
@@ -725,7 +725,7 @@ const BookshelfModel = ModelBase.extend({
    * @param {Object=}  options - Hash of options.
    * @param {boolean=} [options.require=false]
    *
-   *  Rejects the returned promise with an `EmptyError` if no records are returned.
+   *  Rejects the returned promise with an `Collection.EmptyError` if no records are returned.
    *
    * @param {Transaction=} options.transacting
    *
@@ -734,7 +734,7 @@ const BookshelfModel = ModelBase.extend({
    * @fires Model#"fetching:collection"
    * @fires Model#"fetched:collection"
    *
-   * @throws {Model.EmptyError}
+   * @throws {Collection.EmptyError}
    *
    *  Rejects the promise in the event of an empty response if the `require: true` option.
    *
@@ -1282,8 +1282,8 @@ const BookshelfModel = ModelBase.extend({
      * @class Model.NotFoundError
      * @description
      *
-     *   Thrown when no records are found by {@link Model#fetch fetch}, {@link
-     *   Model#fetchAll fetchAll} or {@link Model#refresh} when called with the
+     *   Thrown when no records are found by {@link Model#fetch fetch} or
+     *   {@link Model#refresh} when called with the
      *   `{require: true}` option.
      */
     child.NotFoundError = createError(this.NotFoundError)


### PR DESCRIPTION
The documentation was a bit mixed up about which errors are thrown by which methods, and where those errors are stored.

####`EmptyError`:
* Is stored on `Collection`
* Is thrown by `Model#fetchAll` and `Collection#fetch`

####`NotFoundError`:
* Is stored on `Model`
* Is thrown by `Model#fetch` and `Model#refresh`