### PR TITLE
Fix `Events#trigger` documentation

### DIFF
--- a/src/base/events.js
+++ b/src/base/events.js
@@ -56,7 +56,7 @@ export default class Events extends EventEmitter {
   /**
    * @method Events#trigger
    * @description
-   * Deregister an event listener.
+   * Trigger all registered callbacks for the named event(s).
    * @see {@link http://backbonejs.org/#Events-trigger Backbone.js `Events#trigger`}
    */
   trigger(nameOrNames, ...args) {


### PR DESCRIPTION
It said it would deregister an event handler (matching the `Events#off` documentation, which I thought I'd fixed, but apparently missed a spot)