### PR TITLE
Updates `Model#query` and `Collection#query` documentation

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -285,17 +285,22 @@ const BookshelfCollection = CollectionBase.extend({
    * @method Collection#query
    * @description
    *
-   * `query` is used to tap into the underlying Knex query builder instance for
-   * the current collection. If called with no arguments, it will return the
-   * query builder directly. Otherwise, it will call the specified `method` on
-   * the query builder, applying any additional arguments from the
-   * `collection.query` call. If the `method` argument is a function, it will be
-   * called with the Knex query builder as the context and the first argument.
+   * The `query` method is used to tap into the underlying Knex query builder
+   * instance for the current collection. If called with no arguments, it will
+   * return the query builder directly. If the first argument is a string, `query`
+   * will call the specified method on the query builder, applying any additional
+   * arguments from the `collection.query` call. If the first argument is a
+   * function, it will be called with the Knex query builder as the context
+   * and the first argument, returning the current model. If the first
+   * argument is an object, it must be a dictionary of method-arguments
+   * pairs. For each pair, `query` will call the specified method on the
+   * query builder. The value is an argument or array of arguments that will
+   * be passed.
    *
    * @example
    *
    * let qb = collection.query();
-   *     qb.where({id: 1}).select().then(function(resp) {...
+   *     qb.where({id: 1}).select().then(function(resp) { //...
    *
    * collection.query(function(qb) {
    *   qb.where('id', '>', 5).andWhere('first_name', '=', 'Test');
@@ -304,14 +309,18 @@ const BookshelfCollection = CollectionBase.extend({
    *
    * collection
    *   .query('where', 'other_id', '=', '5')
+   *   .query({whereNot: ['name', 'LIKE', '%Doe']})
    *   .fetch()
    *   .then(function(collection) {
-   *     ...
+   *     // ...
    *   });
    *
-   * @param {function|Object|...string=} arguments The query method.
+   * @param {function|Object|string} [method] The query method, a
+   * callback, or a dictionary of method-argument(s) pairs.
+   * @param {...mixed[]} [args] Arguments to the query method.
    * @returns {Collection|QueryBuilder}
-   *   Will return this model or, if called with no arguments, the underlying query builder.
+   *   Will return this collection or, if called with no arguments, the
+   *   underlying query builder.
    *
    * @see {@link http://knexjs.org/#Builder Knex `QueryBuilder`}
    */

--- a/src/model.js
+++ b/src/model.js
@@ -1135,11 +1135,15 @@ const BookshelfModel = ModelBase.extend({
   /**
    * The `query` method is used to tap into the underlying Knex query builder
    * instance for the current model. If called with no arguments, it will
-   * return the query builder directly. Otherwise, it will call the specified
-   * method on the query builder, applying any additional arguments from the
-   * `model.query` call. If the method argument is a function, it will be
-   * called with the Knex query builder as the context and the first argument,
-   * returning the current model.
+   * return the query builder directly. If the first argument is a string, `query`
+   * will call the specified method on the query builder, applying any additional
+   * arguments from the `model.query` call. If the first argument is a
+   * function, it will be called with the Knex query builder as the context
+   * and the first argument, returning the current model. If the first
+   * argument is an object, it must be a dictionary of method-arguments
+   * pairs. For each pair, `query` will call the specified method on the
+   * query builder. The value is an argument or array of arguments that will
+   * be passed.
    *
    * @example
    *
@@ -1151,6 +1155,7 @@ const BookshelfModel = ModelBase.extend({
    *   });
    *
    * model
+   *   .query({whereNot: ['name', 'LIKE', '%Doe']})
    *   .query({where: {other_id: '5'}, orWhere: {key: 'value'}})
    *   .fetch()
    *   .then(function(model) {
@@ -1166,7 +1171,9 @@ const BookshelfModel = ModelBase.extend({
    *     qb.where({id: 1}).select().then(function(resp) { // ...
    *
    * @method Model#query
-   * @param {function|Object|...string=} arguments The query method.
+   * @param {function|Object|string} [method] The query method, a
+   * callback, or a dictionary of method-argument(s) pairs.
+   * @param {...mixed[]} [args] Arguments to the query method.
    * @returns {Model|QueryBuilder}
    *   Will return this model or, if called with no arguments, the underlying query builder.
    *


### PR DESCRIPTION
- explains how to pass a dictionary of method-arguments pairs
- updates `@param` names and types to clarify different usages