### PR TITLE
add link to website in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bookshelf is a JavaScript ORM for Node.js, built on the [Knex](http://knexjs.org
 
 It is designed to work well with PostgreSQL, MySQL, and SQLite3.
 
-The project is [hosted on GitHub](http://github.com/tgriesser/bookshelf/), and has a comprehensive [test suite](https://travis-ci.org/tgriesser/bookshelf).
+[Website and documentation](http://bookshelfjs.org). The project is [hosted on GitHub](http://github.com/tgriesser/bookshelf/), and has a comprehensive [test suite](https://travis-ci.org/tgriesser/bookshelf).
 
 ## Introduction
 


### PR DESCRIPTION
Previously the website couldn't be accessed directly from [npm](https://www.npmjs.com/package/bookshelf) and you would have to go to the GitHub's repository first to find the link for the website. Also, the word `documentation` was only mentioned in the README.md for Knex's documentation making the website unaccessible from the [README.md](https://github.com/tgriesser/bookshelf/blob/5837a19ce198582ea68befe68f8e13905a4a5d29/README.md).