### PR TITLE
Collection#through is not private

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -40,7 +40,6 @@ const BookshelfCollection = CollectionBase.extend({
 
   /**
    * @method Collection#through
-   * @private
    * @description
    * Used to define passthrough relationships - `hasOne`, `hasMany`, `belongsTo`
    * or `belongsToMany`, "through" an `Interim` model or collection.


### PR DESCRIPTION
Collection#through is not a private method, but it's marked as private in the JSDoc, meaning it doesn't appear in the documentation.

Some of the code examples for [Model#through](http://bookshelfjs.org/#Model-instance-through) actually call Collection#through, for example:

    // Find all paragraphs associated with this book, by
    // passing through the "Chapter" model.
    paragraphs: function() {
      return this.hasMany(Paragraph).through(Chapter);
    },
