### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ var bookshelf = require('bookshelf')(knex);
 
 var User = bookshelf.Model.extend({
   tableName: 'users',
-  messages: function() {
+  posts: function() {
     return this.hasMany(Posts);
   }
 });


### PR DESCRIPTION
User model is fetched with `{withRelated: ['posts.tags']}`, so the association should be named `posts` instead of `messages`.