### PR TITLE
Add toString() knex debug to query event

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint": "^0.23.0",
     "istanbul": "^0.3.19",
     "jsdoc": "^3.3.1",
-    "knex": "^0.8.0",
+    "knex": "git://github.com/tgriesser/knex.git#255daec",
     "minimist": "^1.1.0",
     "mocha": "^2.0.1",
     "mysql": "^2.5.2",


### PR DESCRIPTION
While developing various applications I have discovered that it's difficult to debug and tail logs for problematic or long running queries in production (or even development) environments, so I added a call to the ```toString()``` method in knex from the queryBuilder. Perhaps this could exist as a different event rather than a complex object? This is very useful to copy queries from logs and dump into PGAdmin or Sequel Pro or the DB interface to test a specific query. I couldn't find any specific tests for the query event, aside from the class level one, but I'm happy to add one.