### PR TITLE
Updated docs for Model#fetching event to make note of options.query property

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -153,9 +153,14 @@ _.extend(Sync.prototype, {
        * event handler for async behaviour.
        *
        * @event Model#fetching
-       * @param   {Model}    model      The model that has been fetched.
-       * @param   {string[]} columns    The columns being retrieved by the query.
-       * @param   {Object}   options    Options object passed to {@link Model#fetch fetch}.
+       * @param   {Model}    model      The model which is about to be fetched.
+       * @param   {string[]} columns    The columns to be retrieved by the query.
+       * @param   {Object}   options
+       *
+       *   Options object passed to {@link Model#fetch fetch}, with an
+       *   additional `query` property exposing the Knex query builder to be
+       *   used for fetching.
+       *
        * @returns {Promise}
        */
       return this.syncing.triggerThen('fetching', this.syncing, columns, options);


### PR DESCRIPTION
This property exposes the query builder to be used for the fetch, which previously wasn't documented. This can be used to constrain the query prior to  execution, as shown in #1103.

Tested by building the docs, seems to work OK.