### PR TITLE
bug fix: collection.count() with hasMany relationship properly constrained

### DIFF
--- a/bookshelf.js
+++ b/bookshelf.js
@@ -1,4 +1,4 @@
-require('babel-polyfill');
+if (!global._babelPolyfill) { require('babel-polyfill'); }
 
 /**
  * (c) 2014 Tim Griesser

--- a/test/integration/collection.js
+++ b/test/integration/collection.js
@@ -13,15 +13,13 @@ module.exports = function(bookshelf) {
     var json    = function(model) {
       return JSON.parse(JSON.stringify(model));
     };
-    var checkCount = function(ctx) {
-      var formatNumber = {
-        mysql:      _.identity,
-        sqlite3:    _.identity,
-        postgresql: function(count) { return count.toString() }
-      }[dialect];
-      return function(actual, expected) {
-        expect(actual, formatNumber(expected));
-      }
+    var formatNumber = {
+      mysql:      _.identity,
+      sqlite3:    _.identity,
+      postgresql: function(count) { return count.toString() }
+    }[dialect];
+    var checkCount = function(actual, expected) {
+      expect(actual).to.equal(formatNumber(expected));
     };
     var checkTest = function(ctx) {
       return function(resp) {

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -21,16 +21,14 @@ module.exports = function(bookshelf) {
       del:    function() { return Promise.resolve({}); }
     };
 
-    var checkCount = function(ctx) {
-      var dialect = bookshelf.knex.client.dialect;
-      var formatNumber = {
-        mysql:      _.identity,
-        sqlite3:    _.identity,
-        postgresql: function(count) { return count.toString() }
-      }[dialect];
-      return function(actual, expected) {
-        expect(actual, formatNumber(expected));
-      }
+    var dialect = bookshelf.knex.client.dialect;
+    var formatNumber = {
+      mysql:      _.identity,
+      sqlite3:    _.identity,
+      postgresql: function(count) { return count.toString() }
+    }[dialect];
+    var checkCount = function(actual, expected) {
+      expect(actual, formatNumber(expected));
     };
 
     describe('extend/constructor/initialize', function() {
@@ -695,12 +693,12 @@ module.exports = function(bookshelf) {
 
       it('resets query after completing', function() {
         var posts =  Models.Post.collection();
-        posts.query('where', 'blog_id', 2).count()
+        posts.query('where', 'blog_id', 1).count()
           .then(function(count)  {
             checkCount(count, 2);
             return posts.count();
           })
-          .then(function(count) { checkCount(count, 2); });
+          .then(function(count) { checkCount(count, 5); });
       });
 
     });


### PR DESCRIPTION
`collection.count()` calls were not preserving relations constraints on `hasMany` relationships.

For example, the following was counting all records from related table, not just those related by foreign key:

```javascript
Blog.forge({id: someId}).posts().count();
```

This has been corrected in the src/sync.js class. The `constrain` function was being called for both `Sync#select` and `Sync#count` calls, but was only taking into account `through` relations.

The `constrain` function has been removed and the logic within has be separated out into `Sync#select` and `Sync#count` as they have slightly different requirements.

Also, some integration tests were updated as they were reporting false positives.

Please refer to issue #126 for more information.