### PR TITLE
Make 'fetched' event work for eagerly loaded relations

### DIFF
--- a/src/eager.js
+++ b/src/eager.js
@@ -89,7 +89,7 @@ export default class EagerRelation extends EagerBase {
         return new EagerRelation(relatedModels, response, relatedModel).fetch(options).return(response);
       }
     }).tap(() => {
-      return Promise.each(relatedModels, (model) => model.triggerThen('fetched', model, model.attributes, options));
+      return Promise.map(relatedModels, (model) => model.triggerThen('fetched', model, model.attributes, options));
     });
   }
 

--- a/src/eager.js
+++ b/src/eager.js
@@ -89,7 +89,7 @@ export default class EagerRelation extends EagerBase {
         return new EagerRelation(relatedModels, response, relatedModel).fetch(options).return(response);
       }
     }).tap(() => {
-      return Promise.each(relatedModels, (model) => model.triggerThen('fetched', model, {}, options));
+      return Promise.each(relatedModels, (model) => model.triggerThen('fetched', model, model.attributes, options));
     });
   }
 

--- a/src/eager.js
+++ b/src/eager.js
@@ -74,19 +74,23 @@ export default class EagerRelation extends EagerBase {
     const relatedModels = this.pushModels(relationName, handled, response);
     const relatedData   = handled.relatedData;
 
-    // If there is a response, fetch additional nested eager relations, if any.
-    if (response.length > 0 && options.withRelated) {
-      const relatedModel = relatedData.createModel();
+    return Promise.try(() => {
+      // If there is a response, fetch additional nested eager relations, if any.
+      if (response.length > 0 && options.withRelated) {
+        const relatedModel = relatedData.createModel();
 
-      // If this is a `morphTo` relation, we need to do additional processing
-      // to ensure we don't try to load any relations that don't look to exist.
-      if (relatedData.type === 'morphTo') {
-        const withRelated = this._filterRelated(relatedModel, options);
-        if (withRelated.length === 0) return;
-        options = _.extend({}, options, {withRelated: withRelated});
+        // If this is a `morphTo` relation, we need to do additional processing
+        // to ensure we don't try to load any relations that don't look to exist.
+        if (relatedData.type === 'morphTo') {
+          const withRelated = this._filterRelated(relatedModel, options);
+          if (withRelated.length === 0) return;
+          options = _.extend({}, options, {withRelated: withRelated});
+        }
+        return new EagerRelation(relatedModels, response, relatedModel).fetch(options).return(response);
       }
-      return new EagerRelation(relatedModels, response, relatedModel).fetch(options).return(response);
-    }
+    }).tap(() => {
+      return Promise.each(relatedModels, (model) => model.triggerThen('fetched', model, {}, options));
+    });
   }
 
   // Filters the `withRelated` on a `morphTo` relation, to ensure that only valid

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -147,6 +147,53 @@ module.exports = function(Bookshelf) {
           });
         });
 
+        describe('emits \'fetching\' and \'fetched\' events for eagerly loaded relations with', function () {
+
+          afterEach(function () {
+            delete Site.prototype.initialize;
+          });
+
+          it('withRelated option', function () {          
+            var countFetching = 0;
+            var countFetched = 0;
+            Site.prototype.initialize = function () {
+              this.on('fetching', function () {
+                countFetching++;
+              });
+              this.on('fetched', function () {
+                countFetched++;
+              });
+            };
+            return Blog.forge({id: 1}).fetch({withRelated: ['site']})
+            .then(function() {
+              equal(countFetching, 1);
+              equal(countFetched, 1);
+            });
+          });
+
+          it('load() method', function () {
+            var countFetching = 0;
+            var countFetched = 0;
+            Site.prototype.initialize = function () {
+              this.on('fetching', function () {
+                countFetching++;
+              });
+              this.on('fetched', function () {
+                countFetched++;
+              });
+            };
+            return Blog.where({id: 1}).fetch()
+            .then(function (blog) {
+              return blog.load('site')
+              .then(function() {
+                equal(countFetching, 1);
+                equal(countFetched, 1);
+              });
+            })
+          });
+
+        });
+
       });
 
       describe('Eager Loading - Collections', function() {


### PR DESCRIPTION
As the title says.

It took me many hours hours to unerstand the process of eager loading. I hope that I finally found the right place to trigger the 'fetched' event.

Two tests created for this improvement.

This PR could be related with issues #1151 and #696.

Any comments? I would be glad if this could get merged.
