### PR TITLE
Documentation example now showing correct bcrypt compare usage

### DIFF
--- a/src/base/model.js
+++ b/src/base/model.js
@@ -621,7 +621,7 @@ _.each(modelMethods, function(method) {
  *       login: Promise.method(function(email, password) {
  *         if (!email || !password) throw new Error('Email and password are both required');
  *         return new this({email: email.toLowerCase().trim()}).fetch({require: true}).tap(function(customer) {
- *           return bcrypt.compareAsync(customer.get('password'), password)
+ *           return bcrypt.compareAsync(password, customer.get('password'))
  *            .then(function(res) {
  *              if (!res) throw new Error('Invalid password');
  *            });


### PR DESCRIPTION
bcrypt.compare takes plain password first, hash second

As documented here https://github.com/ncb000gt/node.bcrypt.js#to-check-a-password