### PR TITLE
Fix #1197

### DIFF
--- a/src/base/collection.js
+++ b/src/base/collection.js
@@ -67,11 +67,11 @@ inherits(CollectionBase, Events);
 // here because `clone` needs to duplicate this property. It should not
 // be documented as a valid argument for consumer code.
 //
-// RE: 'attach', 'detach', 'updatePivot', 'withPivot'
+// RE: 'attach', 'detach', 'updatePivot', 'withPivot', '_processPivot', '_processPlainPivot', '_processModelPivot'
 // It's okay to whitelist also given method references to be copied when cloning
 // a collection. These methods are present only when `relatedData` is present and
 // its `type` is 'belongsToMany'. So it is safe to put them in the list and use them
-// without any additional type verification.
+// without any additional verification.
 // These should not be documented as a valid arguments for consumer code.
 const collectionProps = [
   'model', 'comparator', 'relatedData',

--- a/src/base/collection.js
+++ b/src/base/collection.js
@@ -66,7 +66,18 @@ inherits(CollectionBase, Events);
 // `relatedData` does not mutate itself after declaration. This is only
 // here because `clone` needs to duplicate this property. It should not
 // be documented as a valid argument for consumer code.
-const collectionProps = ['model', 'comparator', 'relatedData'];
+//
+// RE: 'attach', 'detach', 'updatePivot', 'withPivot'
+// It's okay to whitelist also given method references to be copied when cloning
+// a collection. These methods are present only when `relatedData` is present and
+// its `type` is 'belongsToMany'. So it is safe to put them in the list and use them
+// without any additional type verification.
+// These should not be documented as a valid arguments for consumer code.
+const collectionProps = [
+  'model', 'comparator', 'relatedData',
+  // `belongsToMany` pivotal collection properties
+  'attach', 'detach', 'updatePivot', 'withPivot', '_processPivot', '_processPlainPivot', '_processModelPivot'
+];
 
 // Copied over from Backbone.
 const setOptions = {add: true, remove: true, merge: true};

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -416,6 +416,20 @@ module.exports = function(Bookshelf) {
             });
         });
 
+        it('keeps the pivotal helper methods when cloning a collection having `relatedData` with `type` "belongsToMany", #1197', function() {
+          var pivotalProps = ['attach', 'detach', 'updatePivot', 'withPivot', '_processPivot', '_processPlainPivot', '_processModelPivot'];
+          var author = new Author({id: 1});
+          posts = author.related('posts');
+          pivotalProps.forEach(function (prop) {
+            expect(posts[prop]).to.be.an.instanceof(Function);
+          });
+
+          clonedAuthor = author.clone()
+          clonedPosts = clonedAuthor.related('posts');
+          pivotalProps.forEach(function (prop) {
+            expect(clonedPosts[prop]).to.equal(posts[prop]);
+          });
+        });
       });
 
       describe('Updating pivot tables with `updatePivot`', function () {

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -419,13 +419,13 @@ module.exports = function(Bookshelf) {
         it('keeps the pivotal helper methods when cloning a collection having `relatedData` with `type` "belongsToMany", #1197', function() {
           var pivotalProps = ['attach', 'detach', 'updatePivot', 'withPivot', '_processPivot', '_processPlainPivot', '_processModelPivot'];
           var author = new Author({id: 1});
-          posts = author.related('posts');
+          var posts = author.related('posts');
           pivotalProps.forEach(function (prop) {
             expect(posts[prop]).to.be.an.instanceof(Function);
           });
 
-          clonedAuthor = author.clone()
-          clonedPosts = clonedAuthor.related('posts');
+          var clonedAuthor = author.clone()
+          var clonedPosts = clonedAuthor.related('posts');
           pivotalProps.forEach(function (prop) {
             expect(clonedPosts[prop]).to.equal(posts[prop]);
           });


### PR DESCRIPTION
Fix #1197

Just add missing pivotal helper properties keys to [`collectionProps`](https://github.com/tgriesser/bookshelf/blob/6ba28f5acec8ea256a63d6268bdb4d8e4ea0634d/src/base/collection.js#L69).
```js
// Change this
/*69*/ const collectionProps = ['model', 'comparator', 'relatedData'];
// to this
/*69*/ const collectionProps = ['model', 'comparator', 'relatedData', 'attach', 'detach', 'updatePivot', 'withPivot', '_processPivot', '_processPlainPivot', '_processModelPivot'];
```
These keys apply only for collection which has `relatedData.type` with value 'belongsToMany'. For other collections these properties are not present. 

To test this bug/modification one test has been added.