### PR TITLE
Update min lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "create-error": "~0.3.1",
     "inflection": "^1.5.1",
     "inherits": "~2.0.1",
-    "lodash": "^3.7.0"
+    "lodash": "^3.8.0"
   },
   "devDependencies": {
     "babel-cli": "^6.0.15",


### PR DESCRIPTION
[ModelBase](https://github.com/tgriesser/bookshelf/blob/82bdcfe4e44f5d2651c85df2e9fec404e154b3c9/src/base/model.js) uses [mapKeys](https://lodash.com/docs#mapKeys) which didn't exist until v3.8.0