### PR TITLE
Added a reference to the query to options before triggering the counting event

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -78,6 +78,7 @@ _.extend(Sync.prototype, {
         }
       });
     }).then(function() {
+      options.query = knex;
       return this.syncing.triggerThen('counting', this.syncing, options);
     }).then(function() {
       return knex.count((column || '*') + ' as count');


### PR DESCRIPTION
All other pre-sync events include a reference to the query in the options object so you can make changes to the query, this adds that reference for the `counting` event.