### PR TITLE
Fix Travis CI by restoring `postinstall` script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "babel -q -L -D ./src/ --out-dir ./lib/",
     "lint": "eslint bookshelf.js src/",
     "cover": "npm run lint && istanbul cover _mocha -- --check-leaks -t 5000 -b -R spec test/index.js",
-    "test": "npm run lint && mocha --check-leaks -t 5000 -b test/index.js",
+    "test": "npm run lint && npm run build && mocha --check-leaks -t 5000 -b test/index.js",
     "jsdoc": "./scripts/jsdoc.sh"
   },
   "homepage": "http://bookshelfjs.org",


### PR DESCRIPTION
`postinstall` script got lost by https://github.com/tgriesser/bookshelf/commit/61f287ba09d3ae2cce45656d34e3d8729bf2fb9d. Restore it.