### PR TITLE
Remove two linter warnings

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -79,12 +79,12 @@ _.extend(Sync.prototype, {
       });
     }).then(function() {
       options.query = knex;
-      
+
       /**
        * Counting event.
        *
        * Fired before a `count` query. A promise may be
-       * returned from the event handler for async behaviour. 
+       * returned from the event handler for async behaviour.
        *
        * @event Model#counting
        * @param {Model}  model    The model firing the event.


### PR DESCRIPTION
> /home/travis/build/vellotis/bookshelf/src/sync.js
>   warning  Trailing spaces not allowed  no-trailing-spaces
>   warning  Trailing spaces not allowed  no-trailing-spaces
>
> ✖ 2 problems (0 errors, 2 warnings)