### PR TITLE
Update to bluebird@3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "babel-runtime": "^6.6.1",
-    "bluebird": "^2.9.4",
+    "bluebird": "^3.4.3",
     "chalk": "^1.0.0",
     "create-error": "~0.3.1",
     "inflection": "^1.5.1",

--- a/test/integration.js
+++ b/test/integration.js
@@ -13,7 +13,7 @@ module.exports = function(Bookshelf) {
     connection: config.mysql,
     pool: {
       afterCreate: function(connection, callback) {
-        return Promise.promisify(connection.query, connection)("SET sql_mode='TRADITIONAL';", []).then(function() {
+        return Promise.promisify(connection.query, {context: connection})("SET sql_mode='TRADITIONAL';", []).then(function() {
           callback(null, connection);
         });
       }


### PR DESCRIPTION
Fixes #1137 

Note: When I ran the tests locally before introducing the change there was one failing test. It is unrelated to this change.

The failing test was/is: `Integration Tests Dialect: mysql Relations Bookshelf Relations Nested Eager Loading - Models eager loads "hasMany" -> "belongsToMany" (site -> authors.posts)`