### PR TITLE
Upgrade to Lodash 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 ## Change Log
 
+**Next Release**
+
+**BREAKING CHANGE: removal/renaming of certain lodash functions from Model and Collection that were removed in lodash 4**
+* Collection Methods
+    * removed `CollectionBase#collect` => use `CollectionBase#map` instead
+    * removed `CollectionBase#foldl` => use `CollectionBase#reduce` instead
+    * removed `CollectionBase#inject` => use `CollectionBase#reduce` instead
+    * removed `CollectionBase#foldr` => use `CollectionBase#reduceRight` instead
+    * removed `CollectionBase#detect` => use `CollectionBase#find` instead
+    * removed `CollectionBase#select` => use `CollectionBase#filter` instead
+    * removed `CollectionBase#all` => use `CollectionBase#every` instead
+    * removed `CollectionBase#any` => use `CollectionBase#some` instead
+    * removed `CollectionBase#include` => use `CollectionBase#includes` instead
+    * removed `CollectionBase#contains` => use `CollectionBase#includes` instead
+    * removed `CollectionBase#rest` => use `CollectionBase#tail instead`
+    * renamed `CollectionBase#invoke` => `CollectionBase#invokeMap`
+    * split `CollectionBase#max` into `CollectionBase#maxBy` - see the [lodash docs](https://lodash.com/docs/#max) for more explanation
+    * split `CollectionBase#min` into `CollectionBase#minBy` - see the [lodash docs](https://lodash.com/docs/#min) for more explanation
+* Model Methods
+    * renamed `ModelBase#pairs` => `ModelBase#toPairs`
+
 **0.9.5** — <small>_May 15, 2016_</small> — [Diff](https://github.com/tgriesser/bookshelf/compare/0.9.4...0.9.5)
 
 * Add pagination plugin. #1183

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "active record"
   ],
   "dependencies": {
-    "bluebird": "^2.9.4",
     "babel-runtime": "^6.6.1",
+    "bluebird": "^2.9.4",
     "chalk": "^1.0.0",
     "create-error": "~0.3.1",
     "inflection": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "create-error": "~0.3.1",
     "inflection": "^1.5.1",
     "inherits": "~2.0.1",
-    "lodash": "^3.8.0"
+    "lodash": "^4.13.1"
   },
   "devDependencies": {
     "babel-cli": "^6.0.15",

--- a/src/base/collection.js
+++ b/src/base/collection.js
@@ -2,7 +2,7 @@
 // ---------------
 
 // All exernal dependencies required in this scope.
-import _, { invoke, noop } from 'lodash';
+import _, { invokeMap, noop } from 'lodash';
 import inherits from 'inherits';
 
 // All components that need to be referenced in this scope.
@@ -136,7 +136,7 @@ CollectionBase.prototype.toString = function() {
  * @returns {Object} Serialized model as a plain object.
  */
 CollectionBase.prototype.serialize = function(options) {
-  return invoke(this.models, 'toJSON', options);
+  return invokeMap(this.models, 'toJSON', options);
 }
 
 /**
@@ -299,7 +299,7 @@ CollectionBase.prototype.mapThen = function(iterator, context) {
  *   Promise resolving to array of results from invocation.
  */
 CollectionBase.prototype.invokeThen = function() {
-  return Promise.all(this.invoke.apply(this, arguments));
+  return Promise.all(this.invokeMap.apply(this, arguments));
 };
 
 /**
@@ -547,7 +547,7 @@ CollectionBase.prototype.sort = function(options) {
  * @returns {mixed[]} An array of attribute values.
  */
 CollectionBase.prototype.pluck = function(attr) {
-  return this.invoke('get', attr);
+  return this.invokeMap('get', attr);
 };
 
 /**
@@ -599,44 +599,20 @@ CollectionBase.prototype._reset = function() {
  * @see http://lodash.com/docs/#map
  */
 /**
- * @method CollectionBase#collect
- * @see http://lodash.com/docs/#collect
- */
-/**
  * @method CollectionBase#reduce
  * @see http://lodash.com/docs/#reduce
- */
-/**
- * @method CollectionBase#foldl
- * @see http://lodash.com/docs/#foldl
- */
-/**
- * @method CollectionBase#inject
- * @see http://lodash.com/docs/#inject
  */
 /**
  * @method CollectionBase#reduceRight
  * @see http://lodash.com/docs/#reduceRight
  */
 /**
- * @method CollectionBase#foldr
- * @see http://lodash.com/docs/#foldr
- */
-/**
  * @method CollectionBase#find
  * @see http://lodash.com/docs/#find
  */
 /**
- * @method CollectionBase#detect
- * @see http://lodash.com/docs/#detect
- */
-/**
  * @method CollectionBase#filter
  * @see http://lodash.com/docs/#filter
- */
-/**
- * @method CollectionBase#select
- * @see http://lodash.com/docs/#select
  */
 /**
  * @method CollectionBase#reject
@@ -647,36 +623,32 @@ CollectionBase.prototype._reset = function() {
  * @see http://lodash.com/docs/#every
  */
 /**
- * @method CollectionBase#all
- * @see http://lodash.com/docs/#all
- */
-/**
  * @method CollectionBase#some
  * @see http://lodash.com/docs/#some
  */
 /**
- * @method CollectionBase#any
- * @see http://lodash.com/docs/#any
+ * @method CollectionBase#includes
+ * @see http://lodash.com/docs/#includes
  */
 /**
- * @method CollectionBase#include
- * @see http://lodash.com/docs/#include
- */
-/**
- * @method CollectionBase#contains
- * @see http://lodash.com/docs/#contains
- */
-/**
- * @method CollectionBase#invoke
- * @see http://lodash.com/docs/#invoke
+ * @method CollectionBase#invokeMap
+ * @see http://lodash.com/docs/#invokeMap
  */
 /**
  * @method CollectionBase#max
  * @see http://lodash.com/docs/#max
  */
 /**
+ * @method CollectionBase#maxBy
+ * @see http://lodash.com/docs/#maxBy
+ */
+/**
  * @method CollectionBase#min
  * @see http://lodash.com/docs/#min
+ */
+/**
+ * @method CollectionBase#minBy
+ * @see http://lodash.com/docs/#minBy
  */
 /**
  * @method CollectionBase#toArray
@@ -701,10 +673,6 @@ CollectionBase.prototype._reset = function() {
 /**
  * @method CollectionBase#initial
  * @see http://lodash.com/docs/#initial
- */
-/**
- * @method CollectionBase#rest
- * @see http://lodash.com/docs/#rest
  */
 /**
  * @method CollectionBase#tail
@@ -749,19 +717,16 @@ CollectionBase.prototype._reset = function() {
 // Lodash methods that we want to implement on the Collection.
 // 90% of the core usefulness of Backbone Collections is actually implemented
 // right here:
-const methods = ['forEach', 'each', 'map', 'collect', 'reduce', 'foldl',
-  'inject', 'reduceRight', 'foldr', 'find', 'detect', 'filter', 'select',
-  'reject', 'every', 'all', 'some', 'any', 'include', 'contains', 'invoke',
-  'max', 'min', 'toArray', 'size', 'first', 'head', 'take', 'initial', 'rest',
+const methods = ['forEach', 'each', 'map', 'reduce', 'reduceRight',
+  'find', 'filter', 'every', 'some', 'includes', 'invokeMap',
+  'max', 'min', 'maxBy', 'minBy', 'toArray', 'size', 'first', 'head', 'take', 'initial',
   'tail', 'drop', 'last', 'without', 'difference', 'indexOf', 'shuffle',
   'lastIndexOf', 'isEmpty', 'chain'];
 
 // Mix in each Lodash method as a proxy to `Collection#models`.
 _.each(methods, function(method) {
   CollectionBase.prototype[method] = function() {
-    const args = slice.call(arguments);
-    args.unshift(this.models);
-    return _[method].apply(_, args);
+    return _[method](this.models, ...arguments);
   };
 });
 
@@ -788,7 +753,7 @@ _.each(attributeMethods, function(method) {
     const iterator = _.isFunction(value) ? value : function(model) {
       return model.get(value);
     };
-    return _[method](this.models, iterator, context);
+    return _[method](this.models, _.bind(iterator, context));
   };
 });
 

--- a/src/base/model.js
+++ b/src/base/model.js
@@ -1,7 +1,6 @@
 // Base Model
 // ---------------
-import _, { assign, identity, mapKeys, mapValues } from 'lodash';
-import { clone } from 'lodash/lang';
+import _, { assign, identity, mapKeys, mapValues, clone } from 'lodash';
 import inherits from 'inherits';
 
 import Events from './events';
@@ -536,7 +535,7 @@ ModelBase.prototype.previous = function(attribute) {
  * @returns {Object} The attributes as they were before the last change.
  */
 ModelBase.prototype.previousAttributes = function() {
-  return _.clone(this._previousAttributes);
+  return clone(this._previousAttributes);
 };
 
 /**
@@ -550,7 +549,7 @@ ModelBase.prototype.previousAttributes = function() {
  * @returns {Model} This model.
  */
 ModelBase.prototype._reset = function() {
-  this._previousAttributes = _.clone(this.attributes);
+  this._previousAttributes = clone(this.attributes);
   this.changed = Object.create(null);
   return this;
 };
@@ -564,8 +563,8 @@ ModelBase.prototype._reset = function() {
  * @see http://lodash.com/docs/#values
  */
 /**
- * @method ModelBase#pairs
- * @see http://lodash.com/docs/#pairs
+ * @method ModelBase#toPairs
+ * @see http://lodash.com/docs/#toPairs
  */
 /**
  * @method ModelBase#invert
@@ -580,12 +579,12 @@ ModelBase.prototype._reset = function() {
  * @see http://lodash.com/docs/#omit
  */
 // "_" methods that we want to implement on the Model.
-const modelMethods = ['keys', 'values', 'pairs', 'invert', 'pick', 'omit'];
+const modelMethods = ['keys', 'values', 'toPairs', 'invert', 'pick', 'omit'];
 
 // Mix in each "_" method as a proxy to `Model#attributes`.
 _.each(modelMethods, function(method) {
-  ModelBase.prototype[method] = function(...args) {
-    return _[method](this.attributes, ...args);
+  ModelBase.prototype[method] = function() {
+    return _[method](this.attributes, ...arguments);
   };
 });
 

--- a/src/base/relation.js
+++ b/src/base/relation.js
@@ -1,7 +1,7 @@
 // Base Relation
 // ---------------
 
-import _, { assign } from 'lodash';
+import { assign, result } from 'lodash';
 import CollectionBase from './collection';
 import extend from '../extend';
 
@@ -11,8 +11,8 @@ export default class RelationBase {
 
   constructor(type, Target, options) {
     if (Target != null) {
-      this.targetTableName   = _.result(Target.prototype, 'tableName');
-      this.targetIdAttribute = _.result(Target.prototype, 'idAttribute');
+      this.targetTableName   = result(Target.prototype, 'tableName');
+      this.targetIdAttribute = result(Target.prototype, 'idAttribute');
     }
     assign(this, { type, target: Target }, options);
   }

--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { extend, result, isString, isArray, isFunction, each } from 'lodash';
 import helpers from './helpers';
 
 // We've supplemented `Events` with a `triggerThen` method to allow for
@@ -37,9 +37,9 @@ function Bookshelf(knex) {
     // `relation` method, passing in the correct `Model` & `Collection`
     // constructors for later reference.
     _relation(type, Target, options) {
-      if (type !== 'morphTo' && !_.isFunction(Target)) {
+      if (type !== 'morphTo' && !isFunction(Target)) {
         throw new Error('A valid target model must be defined for the ' +
-          _.result(this, 'tableName') + ' ' + type + ' relation');
+          result(this, 'tableName') + ' ' + type + ' relation');
       }
       return new Relation(type, Target, options);
     }
@@ -86,7 +86,7 @@ function Bookshelf(knex) {
      * @returns {Collection}
      */
     collection(models, options) {
-      return new bookshelf.Collection((models || []), _.extend({}, options, {model: this}));
+      return new bookshelf.Collection((models || []), extend({}, options, {model: this}));
     },
 
     /**
@@ -178,7 +178,7 @@ function Bookshelf(knex) {
   // in the `Events` object. It also contains the version number, and a
   // `Transaction` method referencing the correct version of `knex` passed into
   // the object.
-  _.extend(bookshelf, Events, Errors, {
+  extend(bookshelf, Events, Errors, {
 
     /**
      * @method Bookshelf#transaction
@@ -242,7 +242,7 @@ function Bookshelf(knex) {
     // `Bookshelf` instance, injecting the current instance into the plugin,
     // which should be a module.exports.
     plugin(plugin, options) {
-      if (_.isString(plugin)) {
+      if (isString(plugin)) {
         try {
           require('./plugins/' + plugin)(this, options);
         } catch (e) {
@@ -253,8 +253,8 @@ function Bookshelf(knex) {
             require(plugin)(this, options)
           }
         }
-      } else if (_.isArray(plugin)) {
-        _.each(plugin, (p) => {
+      } else if (isArray(plugin)) {
+        each(plugin, (p) => {
           this.plugin(p, options);
         });
       } else {
@@ -284,7 +284,7 @@ function Bookshelf(knex) {
   function builderFn(tableNameOrBuilder) {
     let builder = null;
 
-    if (_.isString(tableNameOrBuilder)) {
+    if (isString(tableNameOrBuilder)) {
       builder = knex(tableNameOrBuilder);
     } else if (tableNameOrBuilder == null) {
       builder = knex.queryBuilder();

--- a/src/collection.js
+++ b/src/collection.js
@@ -375,7 +375,7 @@ const BookshelfCollection = CollectionBase.extend({
 
   /* Ensure that QueryBuilder is copied on clone. */
   clone() {
-    const cloned = CollectionBase.prototype.clone(this, arguments);
+    const cloned = BookshelfCollection.__super__.clone.apply(this, arguments);
     if (this._knex != null) {
       cloned._knex = cloned._builder(this._knex.clone());
     }

--- a/src/collection.js
+++ b/src/collection.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { clone, omit, isString, isArray, extend, toArray } from 'lodash';
 
 import Sync from './sync';
 import Helpers from './helpers';
@@ -80,7 +80,7 @@ const BookshelfCollection = CollectionBase.extend({
    * @returns {Promise<Collection>}
    */
   fetch: Promise.method(function(options) {
-    options = options ? _.clone(options) : {};
+    options = options ? clone(options) : {};
     return this.sync(options)
       .select()
       .bind(this)
@@ -100,7 +100,7 @@ const BookshelfCollection = CollectionBase.extend({
       // level, ensure those are omitted from the options.
       .tap(function(response) {
         if (options.withRelated) {
-          return this._handleEager(response, _.omit(options, 'columns'));
+          return this._handleEager(response, omit(options, 'columns'));
         }
       })
       .tap(function(response) {
@@ -152,11 +152,11 @@ const BookshelfCollection = CollectionBase.extend({
    *   A promise resolving to the number of matching rows.
    */
   count: Promise.method(function(column, options) {
-    if (!_.isString(column)) {
+    if (!isString(column)) {
       options = column;
       column = undefined;
     }
-    if (options) options = _.clone(options);
+    if (options) options = clone(options);
     return this.sync(options).count(column)
   }),
 
@@ -218,8 +218,8 @@ const BookshelfCollection = CollectionBase.extend({
    *  Collection collection}
    */
   load: Promise.method(function(relations, options) {
-    if (!_.isArray(relations)) relations = [relations]
-    options = _.extend({}, options, {shallow: true, withRelated: relations});
+    if (!isArray(relations)) relations = [relations]
+    options = extend({}, options, {shallow: true, withRelated: relations});
     return new EagerRelation(this.models, this.toJSON(options), new this.model())
       .fetch(options)
       .return(this);
@@ -257,7 +257,7 @@ const BookshelfCollection = CollectionBase.extend({
    * model}.
    */
   create: Promise.method(function(model, options) {
-    options = options != null ? _.clone(options) : {};
+    options = options != null ? clone(options) : {};
     const { relatedData } = this;
     model = this._prepareModel(model, options);
 
@@ -273,7 +273,7 @@ const BookshelfCollection = CollectionBase.extend({
       .bind(this)
       .then(function() {
         if (relatedData && relatedData.type === 'belongsToMany') {
-          return this.attach(model, _.omit(options, 'query'));
+          return this.attach(model, omit(options, 'query'));
         }
       })
       .then(function() { this.add(model, options); })
@@ -333,7 +333,7 @@ const BookshelfCollection = CollectionBase.extend({
    * @see {@link http://knexjs.org/#Builder Knex `QueryBuilder`}
    */
   query: function() {
-    return Helpers.query(this, _.toArray(arguments));
+    return Helpers.query(this, toArray(arguments));
   },
 
   /**
@@ -375,7 +375,7 @@ const BookshelfCollection = CollectionBase.extend({
 
   /* Ensure that QueryBuilder is copied on clone. */
   clone() {
-    const cloned = CollectionBase.prototype.clone.apply(this, arguments);
+    const cloned = CollectionBase.prototype.clone(this, arguments);
     if (this._knex != null) {
       cloned._knex = cloned._builder(this._knex.clone());
     }
@@ -391,7 +391,7 @@ const BookshelfCollection = CollectionBase.extend({
    */
   _handleResponse: function(response) {
     const { relatedData } = this;
-    this.set(response, {silent: true, parse: true}).invoke('_reset');
+    this.set(response, {silent: true, parse: true}).invokeMap('_reset');
     if (relatedData && relatedData.isJoined()) {
       relatedData.parsePivot(this.models);
     }

--- a/src/eager.js
+++ b/src/eager.js
@@ -1,13 +1,13 @@
 // EagerRelation
 // ---------------
-import _, { flatten, groupBy, map, mapValues, uniq } from 'lodash';
+import _ from 'lodash';
 
 import Helpers from './helpers';
 import Promise from './base/promise';
 import EagerBase from './base/eager';
 
 const getAttributeUnique = (models, attribute) =>
-  uniq(map(models, m => m.get(attribute)));
+  _.uniq(_.map(models, m => m.get(attribute)));
 
 // An `EagerRelation` object temporarily stores the models from an eager load,
 // and handles matching eager loaded objects with their parent(s). The
@@ -45,12 +45,12 @@ export default class EagerRelation extends EagerBase {
       typeColumn = `${morphName}_type`, idColumn = `${morphName}_id`
     ] = columnNames;
 
-    const parentsByType = groupBy(this.parent, model => model.get(typeColumn));
-    const TargetByType = mapValues(parentsByType, (parents, type) =>
+    const parentsByType = _.groupBy(this.parent, model => model.get(typeColumn));
+    const TargetByType = _.mapValues(parentsByType, (parents, type) =>
       Helpers.morphCandidate(relatedData.candidates, type)
     );
 
-    return Promise.all(map(parentsByType, (parents, type) => {
+    return Promise.all(_.map(parentsByType, (parents, type) => {
       const Target = TargetByType[type];
       const idAttribute = _.result(Target.prototype, 'idAttribute');
       const ids = getAttributeUnique(parents, idColumn);
@@ -66,7 +66,7 @@ export default class EagerRelation extends EagerBase {
             response, relationName, { relatedData: clone }, options
           );
         });
-    })).then(flatten);
+    })).then(_.flatten);
   }
 
   // Handles the eager load for both the `morphTo` and regular cases.

--- a/src/extend.js
+++ b/src/extend.js
@@ -1,7 +1,7 @@
 import { isFunction, assign } from 'lodash';
 
 // Uses a hash of prototype properties and class properties to be extended.
-module.exports = function(protoProps, staticProps) {
+module.exports = function extend(protoProps, staticProps) {
   const Parent = this;
 
   // The constructor function for the new subclass is either defined by you
@@ -9,20 +9,26 @@ module.exports = function(protoProps, staticProps) {
   // by us to simply call the parent's constructor.
   const Child = protoProps && protoProps.hasOwnProperty('constructor')
     ? protoProps.constructor
-    : function(){ Parent.apply(this, arguments); };
+    : function(){ return Parent.apply(this, arguments); };
+
+  assign(Child, Parent, staticProps);
 
   // Set the prototype chain to inherit from `Parent`.
-  Child.prototype = Object.create(Parent.prototype)
+  Child.prototype = Object.create(Parent.prototype, {
+    constructor: {
+      value: Child,
+      enumerable: false,
+      writable: true,
+      configurable: true
+    }
+  });
 
-  // Assign methods and static functions.
-  assign(Child.prototype, protoProps);
-  assign(Child, staticProps);
+  if (protoProps) {
+    assign(Child.prototype, protoProps);
+  }
 
-  // Correctly set child's `prototype.constructor`.
-  Child.prototype.constructor = Child;
-
-  // Add static properties to the constructor function, if supplied.
-  Child.__proto__ = Parent;
+  // Give child access to the parent prototype as part of "super"
+  Child.__super__ = Parent.prototype;
 
   // If there is an "extended" function set on the parent,
   // call it with the extended child object.

--- a/src/extend.js
+++ b/src/extend.js
@@ -1,5 +1,4 @@
-import { isFunction } from 'lodash/lang';
-import { assign } from 'lodash/object';
+import { isFunction, assign } from 'lodash';
 
 // Uses a hash of prototype properties and class properties to be extended.
 module.exports = function(protoProps, staticProps) {

--- a/src/model.js
+++ b/src/model.js
@@ -1233,7 +1233,10 @@ const BookshelfModel = ModelBase.extend({
 
   /* Ensure that QueryBuilder is copied on clone. */
   clone() {
-    const cloned = ModelBase.prototype.clone(...arguments);
+    // This needs to use the direct apply method because the spread operator
+    // incorrectly converts to `clone.apply(ModelBase.prototype, arguments)`
+    // instead of `apply(this, arguments)`
+    const cloned = BookshelfModel.__super__.clone.apply(this, arguments);
     if (this._knex != null) {
       cloned._knex = cloned._builder(this._knex.clone());
     }

--- a/src/model.js
+++ b/src/model.js
@@ -1,4 +1,4 @@
-import _, { assign, isArray } from 'lodash';
+import _ from 'lodash';
 import createError from 'create-error';
 
 import Sync from './sync';
@@ -801,7 +801,7 @@ const BookshelfModel = ModelBase.extend({
    */
   load: Promise.method(function(relations, options) {
     const columns = this.format({ ...this.attributes });
-    const withRelated = isArray(relations) ? relations : [relations];
+    const withRelated = _.isArray(relations) ? relations : [relations];
     return this._handleEager(
       [columns], { ...options, shallow: true, withRelated }
     ).return(this);
@@ -980,7 +980,7 @@ const BookshelfModel = ModelBase.extend({
           const updatedCols = {};
           updatedCols[this.idAttribute] = this.id = resp[0];
           const updatedAttrs = this.parse(updatedCols);
-          assign(this.attributes, updatedAttrs);
+          _.assign(this.attributes, updatedAttrs);
         } else if (method === 'update' && resp === 0) {
           if (options.require !== false) {
             throw new this.constructor.NoRowsUpdatedError('No Rows Updated');
@@ -1233,7 +1233,7 @@ const BookshelfModel = ModelBase.extend({
 
   /* Ensure that QueryBuilder is copied on clone. */
   clone() {
-    const cloned = ModelBase.prototype.clone.apply(this, arguments);
+    const cloned = ModelBase.prototype.clone(...arguments);
     if (this._knex != null) {
       cloned._knex = cloned._builder(this._knex.clone());
     }

--- a/src/plugins/pagination.js
+++ b/src/plugins/pagination.js
@@ -1,5 +1,5 @@
 import Promise from 'bluebird';
-import { remove as _remove, assign as _assign } from 'lodash';
+import { remove, assign } from 'lodash';
 
 const DEFAULT_LIMIT = 10;
 const DEFAULT_OFFSET = 0;
@@ -144,7 +144,7 @@ module.exports = function paginationPlugin (bookshelf) {
       return pager
 
         .query(qb => {
-          _assign(qb, this.query().clone());
+          assign(qb, this.query().clone());
           qb.limit.apply(qb, [_limit]);
           qb.offset.apply(qb, [_offset]);
           return null;
@@ -163,12 +163,12 @@ module.exports = function paginationPlugin (bookshelf) {
       const counter = this.constructor.forge();
 
       return counter.query(qb => {
-        _assign(qb, this.query().clone());
+        assign(qb, this.query().clone());
 
         // Remove grouping and ordering. Ordering is unnecessary
         // for a count, and grouping returns the entire result set
         // What we want instead is to use `DISTINCT`
-        _remove(qb._statements, statement => {
+        remove(qb._statements, statement => {
           return (notNeededQueries.indexOf(statement.type) > -1) ||
             statement.grouping === 'columns';
         });
@@ -199,8 +199,8 @@ module.exports = function paginationPlugin (bookshelf) {
     return Promise.join(paginate(), count())
       .then(([rows, metadata]) => {
         const pageCount = Math.ceil(metadata.rowCount / _limit);
-        const pageData = _assign(metadata, {pageCount});
-        return _assign(rows, {pagination: pageData});
+        const pageData = assign(metadata, {pageCount});
+        return assign(rows, {pagination: pageData});
       });
   }
 

--- a/src/plugins/registry.js
+++ b/src/plugins/registry.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import {isPlainObject, drop, map} from 'lodash';
 
 // Registry Plugin -
 // Create a central registry of model/collection constructors to
@@ -18,7 +18,7 @@ module.exports = function (bookshelf) {
     this._models = this._models || Object.create(null);
     if (ModelCtor) {
       preventOverwrite(this._models, name);
-      if (_.isPlainObject(ModelCtor)) {
+      if (isPlainObject(ModelCtor)) {
         ModelCtor = this.Model.extend(ModelCtor, staticProps);
       }
       this._models[name] = ModelCtor;
@@ -29,7 +29,7 @@ module.exports = function (bookshelf) {
     this._collections = this._collections || Object.create(null);
     if (CollectionCtor) {
       preventOverwrite(this._collections, name);
-      if (_.isPlainObject(CollectionCtor)) {
+      if (isPlainObject(CollectionCtor)) {
         CollectionCtor = this.Collection.extend(CollectionCtor, staticProps);
       }
       this._collections[name] = CollectionCtor;
@@ -60,29 +60,29 @@ module.exports = function (bookshelf) {
   const _relation = Model.prototype._relation;
   Model.prototype._relation = function (method, Target) {
     // The second argument is always a model, so resolve it and call the original method.
-    return _relation.apply(this, [method, resolveModel(Target)].concat(_.drop(arguments, 2)));
+    return _relation.apply(this, [method, resolveModel(Target)].concat(drop(arguments, 2)));
   }
 
   // The `through` method doesn't use `_relation` beneath, so we have to
   // re-implement it specifically
   const through = Model.prototype.through;
   Model.prototype.through = function (Target) {
-    return through.apply(this, [resolveModel(Target)].concat(_.drop(arguments)));
+    return through.apply(this, [resolveModel(Target)].concat(drop(arguments)));
   }
 
   // `morphTo` takes the relation name first, and then a variadic set of models so we
   // can't include it with the rest of the relational methods.
   const morphTo = Model.prototype.morphTo;
   Model.prototype.morphTo = function(relationName) {
-    return morphTo.apply(this, [relationName].concat(_.map(_.drop(arguments), function(model) {
+    return morphTo.apply(this, [relationName].concat(map(drop(arguments), (model) => {
       return resolveModel(model);
-    }, this)));
+    })));
   };
 
   // The `through` method exists on the Collection as well, for `hasMany` / `belongsToMany` through relations.
   const collectionThrough = Collection.prototype.through;
   Collection.prototype.through = function(Target) {
-    return collectionThrough.apply(this, [resolveModel(Target)].concat(_.drop(arguments)));
+    return collectionThrough.apply(this, [resolveModel(Target)].concat(drop(arguments)));
   };
 
 };

--- a/src/plugins/virtuals.js
+++ b/src/plugins/virtuals.js
@@ -75,7 +75,7 @@ module.exports = function (Bookshelf) {
           _.extend(this.patchAttributes, nonVirtuals);
         }
         // Set the non-virtual attributes as normal.
-        return proto.set.call(this, nonVirtuals, value, options);
+        return proto.set.call(this, nonVirtuals, options);
       }
 
       // Handle `"key", value` style arguments for virtual setter.

--- a/src/plugins/virtuals.js
+++ b/src/plugins/virtuals.js
@@ -70,7 +70,7 @@ module.exports = function (Bookshelf) {
 
       // Handle `{key: value}` style arguments.
       if (_.isObject(key)) {
-        const nonVirtuals = _.omit(key, setVirtual, this);
+        const nonVirtuals = _.omitBy(key, _.bind(setVirtual, this));
         if (isPatching) {
           _.extend(this.patchAttributes, nonVirtuals);
         }
@@ -147,14 +147,12 @@ module.exports = function (Bookshelf) {
   });
 
   // Underscore methods that we want to implement on the Model.
-  const modelMethods = ['keys', 'values', 'pairs', 'invert', 'pick', 'omit'];
+  const modelMethods = ['keys', 'values', 'toPairs', 'invert', 'pick', 'omit'];
 
-  // Mix in each Underscore method as a proxy to `Model#attributes`.
+  // Mix in each Lodash method as a proxy to `Model#attributes`.
   _.each(modelMethods, function(method) {
     Model.prototype[method] = function() {
-      const args = _.toArray(arguments);
-      args.unshift(_.extend({}, this.attributes, getVirtuals(this)));
-      return _[method].apply(_, args);
+      return _[method](_.extend({}, this.attributes, getVirtuals(this)), ...arguments);
     };
   });
 

--- a/src/plugins/visibility.js
+++ b/src/plugins/visibility.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { clone, pick, omit } from 'lodash';
 
 // Visibility plugin -
 // Useful for hiding/showing particular attributes on `toJSON`.
@@ -21,10 +21,10 @@ module.exports = function(Bookshelf) {
       proto.constructor.apply(this, arguments);
       const options = arguments[1] || {};
       if (options.visible) {
-        this.visible = _.clone(options.visible);
+        this.visible = clone(options.visible);
       }
       if (options.hidden) {
-        this.hidden = _.clone(options.hidden);
+        this.hidden = clone(options.hidden);
       }
     },
 
@@ -33,10 +33,10 @@ module.exports = function(Bookshelf) {
     toJSON: function() {
       let json = toJSON.apply(this, arguments);
       if (this.visible) {
-        json = _.pick.apply(_, [json].concat(this.visible));
+        json = pick(...[json].concat(this.visible));
       }
       if (this.hidden) {
-        json = _.omit.apply(_, [json].concat(this.hidden));
+        json = omit(...[json].concat(this.hidden));
       }
       return json;
     }

--- a/src/relation.js
+++ b/src/relation.js
@@ -1,9 +1,6 @@
 // Relation
 // ---------------
 import _ from 'lodash';
-import { clone, isEmpty } from 'lodash/lang';
-import { groupBy, map, reduce, each } from 'lodash/collection';
-import { startsWith } from 'lodash/string';
 import inflection from 'inflection';
 
 import Helpers from './helpers';
@@ -14,7 +11,7 @@ import { PIVOT_PREFIX } from './constants';
 
 const { push } = Array.prototype;
 const removePivotPrefix = key => key.slice(PIVOT_PREFIX.length);
-const hasPivotPrefix = key => startsWith(key, PIVOT_PREFIX);
+const hasPivotPrefix = key => _.startsWith(key, PIVOT_PREFIX);
 
 export default RelationBase.extend({
 
@@ -142,7 +139,7 @@ export default RelationBase.extend({
       knex.columns(options.columns);
     }
 
-    const currentColumns = _.findWhere(knex._statements, {grouping: 'columns'});
+    const currentColumns = _.find(knex._statements, {grouping: 'columns'});
 
     if (!currentColumns || currentColumns.length === 0) {
       knex.column(this.targetTableName + '.*');
@@ -244,7 +241,7 @@ export default RelationBase.extend({
     const key = this.isInverse() && !this.isThrough()
       ? this.key('foreignKey')
       : this.parentIdAttribute;
-    return _(response).pluck(key).uniq().value();
+    return _(response).map(key).uniq().value();
   },
 
   // Generates the appropriate standard join table.
@@ -294,7 +291,7 @@ export default RelationBase.extend({
     if (this.isJoined()) related = this.parsePivot(related);
 
     // Group all of the related models for easier association with their parent models.
-    const grouped = groupBy(related, (m) => {
+    const grouped = _.groupBy(related, (m) => {
       if (m.pivot) {
         return this.isInverse() && this.isThrough() ? m.pivot.id :
           m.pivot.get(this.key('foreignKey'));
@@ -305,7 +302,7 @@ export default RelationBase.extend({
 
     // Loop over the `parentModels` and attach the grouped sub-models,
     // keeping the `relatedData` on the new related instance.
-    each(parentModels, (model) => {
+    _.each(parentModels, (model) => {
       let groupedKey;
       if (!this.isInverse()) {
         groupedKey = model.id;
@@ -313,7 +310,7 @@ export default RelationBase.extend({
         const keyColumn = this.key(
           this.isThrough() ? 'throughForeignKey': 'foreignKey'
         );
-        const formatted = model.format(clone(model.attributes));
+        const formatted = model.format(_.clone(model.attributes));
         groupedKey = formatted[keyColumn];
       }
       const relation = model.relations[relationName] = this.relatedInstance(grouped[groupedKey]);
@@ -331,10 +328,10 @@ export default RelationBase.extend({
   },
 
   parsePivot: function(models) {
-    return map(models, (model) => {
+    return _.map(models, (model) => {
 
       // Separate pivot attributes.
-      const grouped = reduce(model.attributes, (acc, value, key) => {
+      const grouped = _.reduce(model.attributes, (acc, value, key) => {
         if (hasPivotPrefix(key)) {
           acc.pivot[removePivotPrefix(key)] = value;
         } else {
@@ -348,7 +345,7 @@ export default RelationBase.extend({
 
       // If there are any pivot attributes, create a new pivot model with these
       // attributes.
-      if (!isEmpty(grouped.pivot)) {
+      if (!_.isEmpty(grouped.pivot)) {
         const Through = this.throughTarget;
         const tableName = this.joinTable();
         model.pivot = Through != null
@@ -532,7 +529,7 @@ const pivotHelpers = {
       if (method === 'delete') pending.push(this._processPivot(method, null, options));
     }
     if (!_.isArray(ids)) ids = ids ? [ids] : [];
-    each(ids, (id) => pending.push(this._processPivot(method, id, options)))
+    _.each(ids, (id) => pending.push(this._processPivot(method, id, options)))
     return Promise.all(pending).return(this);
   }),
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -117,7 +117,7 @@ _.extend(Sync.prototype, {
     // specifications. This could include `distinct()` with no arguments, which
     // does not affect inform the columns returned.
     const queryContainsColumns = _(knex._statements)
-      .where({grouping: 'columns'})
+      .filter({grouping: 'columns'})
       .some('value.length');
 
     return Promise.bind(this).then(function() {
@@ -198,7 +198,7 @@ _.extend(Sync.prototype, {
   update: Promise.method(function(attrs) {
     const syncing = this.syncing, query = this.query;
     if (syncing.id != null) query.where(syncing.idAttribute, syncing.id);
-    if (_.where(query._statements, {grouping: 'where'}).length === 0) {
+    if (_.filter(query._statements, {grouping: 'where'}).length === 0) {
       throw new Error('A model cannot be updated without a "where" clause or an idAttribute.');
     }
     return query.update(syncing.format(_.extend(Object.create(null), attrs)));
@@ -208,7 +208,7 @@ _.extend(Sync.prototype, {
   del: Promise.method(function() {
     const query = this.query, syncing = this.syncing;
     if (syncing.id != null) query.where(syncing.idAttribute, syncing.id);
-    if (_.where(query._statements, {grouping: 'where'}).length === 0) {
+    if (_.filter(query._statements, {grouping: 'where'}).length === 0) {
       throw new Error('A model cannot be destroyed without a "where" clause or an idAttribute.');
     }
     return this.query.del();

--- a/src/sync.js
+++ b/src/sync.js
@@ -41,7 +41,7 @@ _.extend(Sync.prototype, {
     // operator.
     //
     // NOTE: `_.omit` returns an empty object, even if attributes are null.
-    const whereAttributes = _.omit(attributes, _.isPlainObject);
+    const whereAttributes = _.omitBy(attributes, _.isPlainObject);
 
     if (!_.isEmpty(whereAttributes)) {
 

--- a/test/base/tests/events.js
+++ b/test/base/tests/events.js
@@ -1,7 +1,6 @@
 var Promise   = testPromise;
 var assert    = require('assert');
 var equal     = assert.equal;
-var _         = require('lodash');
 
 module.exports = function() {
 

--- a/test/integration/helpers/inserts.js
+++ b/test/integration/helpers/inserts.js
@@ -1,5 +1,4 @@
 var Promise = global.testPromise;
-var _       = require('lodash');
 
 module.exports = function(bookshelf) {
 
@@ -234,13 +233,13 @@ module.exports = function(bookshelf) {
 
     knex('hostnames').insert([
       {hostname: 'google.com', instance_id: 3},
-      {hostname: 'apple.com', instance_id: 10},
+      {hostname: 'apple.com', instance_id: 10}
     ]),
 
     knex('instances').insert([
       {id: 3, name: 'search engine'},
       {id: 4, name: 'not used'},
-      {id: 10, name: 'computers'},
+      {id: 10, name: 'computers'}
     ]),
 
     knex('parsed_users').insert({id: 10, name: 'test'}),

--- a/test/integration/helpers/json/inserts.js
+++ b/test/integration/helpers/json/inserts.js
@@ -1,5 +1,4 @@
 var Promise = global.testPromise;
-var _       = require('lodash');
 
 module.exports = function(bookshelf) {
 

--- a/test/integration/helpers/json/migration.js
+++ b/test/integration/helpers/json/migration.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var Promise = global.testPromise;
 
 var drops = [

--- a/test/integration/helpers/json/migration.js
+++ b/test/integration/helpers/json/migration.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var Promise = global.testPromise;
 
 var drops = [

--- a/test/integration/helpers/json/objects.js
+++ b/test/integration/helpers/json/objects.js
@@ -1,8 +1,5 @@
 // Models used for PostgreSQL jsonb type.
 module.exports = function(Bookshelf) {
-
-  var _ = require('lodash');
-
   var Unit = Bookshelf.Model.extend({
     tableName: 'units',
     commands: function() {

--- a/test/integration/helpers/migration.js
+++ b/test/integration/helpers/migration.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+var _ = require('lodash')
 var Promise = global.testPromise;
 
 var drops = [
@@ -146,7 +146,7 @@ module.exports = function(Bookshelf) {
       table.string('parsed_user_id');
       table.string('token');
     })
-    // 
+    //
     .createTable('lefts', function(table) {
       table.increments();
     })

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -165,35 +165,35 @@ module.exports = function(bookshelf) {
 
       it('passes along additional arguments to the Knex method in the first argument', function() {
         var qb = model.resetQuery().query();
-        equal(_.where(qb._statements, {grouping: 'where'}).length, 0);
+        equal(_.filter(qb._statements, {grouping: 'where'}).length, 0);
         var q = model.query('where', {id:1});
         equal(q, (model));
-        equal(_.where(qb._statements, {grouping: 'where'}).length, 1);
+        equal(_.filter(qb._statements, {grouping: 'where'}).length, 1);
       });
 
       it('allows passing an object to query', function() {
         var qb = model.resetQuery().query();
-        equal(_.where(qb._statements, {grouping: 'where'}).length, 0);
+        equal(_.filter(qb._statements, {grouping: 'where'}).length, 0);
         var q = model.query({where: {id: 1}, orWhere: ['id', '>', '10']});
         equal(q, model);
-        equal(_.where(qb._statements, {grouping: 'where'}).length, 2);
+        equal(_.filter(qb._statements, {grouping: 'where'}).length, 2);
       });
 
       it('allows passing an function to query', function() {
         var qb = model.resetQuery().query();
-        equal(_.where(qb._statements, {grouping: 'where'}).length, 0);
+        equal(_.filter(qb._statements, {grouping: 'where'}).length, 0);
         var q = model.query(function(qb) {
           this.where({id: 1}).orWhere('id', '>', '10');
         });
         equal(q, model);
-        equal(_.where(qb._statements, {grouping: 'where'}).length, 2);
+        equal(_.filter(qb._statements, {grouping: 'where'}).length, 2);
         qb = model.resetQuery().query();
-        equal(_.where(qb._statements, {grouping: 'where'}).length, 0);
+        equal(_.filter(qb._statements, {grouping: 'where'}).length, 0);
         q = model.query(function(qb) {
           qb.where({id: 1}).orWhere('id', '>', '10');
         });
         equal(q, model);
-        equal(_.where(qb._statements, {grouping: 'where'}).length, 2);
+        equal(_.filter(qb._statements, {grouping: 'where'}).length, 2);
       });
 
     });
@@ -519,7 +519,7 @@ module.exports = function(bookshelf) {
         var m = new bookshelf.Model({id: null}).query({where: {uuid: 'testing'}});
         var query = m.query();
         query.update = function() {
-          equal(_.where(this._statements, {grouping: 'where'}).length, 1);
+          equal(_.filter(this._statements, {grouping: 'where'}).length, 1);
           return Promise.resolve(1);
         };
 
@@ -528,7 +528,7 @@ module.exports = function(bookshelf) {
           var m2 = new bookshelf.Model({id: 1}).query({where: {uuid: 'testing'}});
           var query2 = m2.query();
           query2.update = function() {
-            equal(_.where(this._statements, {grouping: 'where'}).length, 2);
+            equal(_.filter(this._statements, {grouping: 'where'}).length, 2);
             return {};
           };
 
@@ -545,7 +545,7 @@ module.exports = function(bookshelf) {
 
         query.then = function(onFulfilled, onRejected) {
           deepEqual(this._single.update, {bio: 'Short user bio'});
-          equal(_.where(this._statements, {grouping: 'where'}).length, 1);
+          equal(_.filter(this._statements, {grouping: 'where'}).length, 1);
           return Promise.resolve(1).then(onFulfilled, onRejected);
         };
 
@@ -764,9 +764,9 @@ module.exports = function(bookshelf) {
 
       it('deletes the `_builder` property, resetting the model query builder', function() {
         var m = new bookshelf.Model().query('where', {id: 1});
-        equal(_.where(m.query()._statements, {grouping: 'where'}).length, 1);
+        equal(_.filter(m.query()._statements, {grouping: 'where'}).length, 1);
         m.resetQuery();
-        equal(_.where(m.query()._statements, {grouping: 'where'}).length, 0);
+        equal(_.filter(m.query()._statements, {grouping: 'where'}).length, 0);
       });
     });
 

--- a/test/integration/plugins/pagination.js
+++ b/test/integration/plugins/pagination.js
@@ -1,7 +1,6 @@
 var Promise = require('bluebird');
 var expect = require('chai').expect;
 var sinon = require('sinon');
-var _ = require('lodash');
 
 module.exports = function (bookshelf) {
 

--- a/test/integration/plugins/virtuals.js
+++ b/test/integration/plugins/virtuals.js
@@ -199,7 +199,7 @@ module.exports = function (bookshelf) {
 
       deepEqual(m.keys(), ['firstName', 'lastName', 'fullName']);
       deepEqual(m.values(), ['Joe', 'Shmoe', 'Joe Shmoe']);
-      deepEqual(m.pairs(), [['firstName', 'Joe'], ['lastName', 'Shmoe'], ['fullName', 'Joe Shmoe']]);
+      deepEqual(m.toPairs(), [['firstName', 'Joe'], ['lastName', 'Shmoe'], ['fullName', 'Joe Shmoe']]);
       deepEqual(m.invert(), {'Joe': 'firstName', 'Shmoe': 'lastName','Joe Shmoe': 'fullName'});
       deepEqual(m.pick('fullName'), {'fullName': 'Joe Shmoe'});
       deepEqual(m.omit('firstName'), {'lastName': 'Shmoe', 'fullName': 'Joe Shmoe'});
@@ -211,7 +211,7 @@ module.exports = function (bookshelf) {
           expect(result.get('first_name')).to.equal('Oderus');
           expect(result.get('last_name')).to.equal('Urungus');
       };
-    
+
       it('by using the `{key: value}` style assignment call', function() {
         var Model = bookshelf.Model.extend({
           tableName: 'authors',
@@ -242,7 +242,7 @@ module.exports = function (bookshelf) {
             return result.destroy();
           });
       });
-      
+
       it('by using the `"key", value` style assignment call', function() {
         var Model = bookshelf.Model.extend({
           tableName: 'authors',

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -1,4 +1,3 @@
-var _         = require('lodash');
 var Promise   = global.testPromise;
 var equal     = require('assert').equal;
 
@@ -153,7 +152,7 @@ module.exports = function(Bookshelf) {
             delete Site.prototype.initialize;
           });
 
-          it('withRelated option', function () {          
+          it('withRelated option', function () {
             var countFetching = 0;
             var countFetched = 0;
             Site.prototype.initialize = function () {
@@ -978,7 +977,7 @@ module.exports = function(Bookshelf) {
             return this.belongsToMany(LeftModel).through(JoinModel).withPivot(['parsedName']);
           }
         });
-      };
+      }
 
       // First, initialize the models for the current `lifecycleEvent`, then
       // step through the entire lifecycle of a JoinModel, returning a promise.


### PR DESCRIPTION
closes #1285 

This hopes to upgrade to lodash 4+ whilst still being backwards-compatible for exiting Bookshelf versions.

Because a decent amount of Bookshelf's api is directly tied into Lodash's API, this requires a decent amount of refactoring in certain parts.

This is still a WIP, but I wanted to clarify I was heading in the right direction first.

/cc @rhys-vdw @ErisDS