### PR TITLE
Fix belongsToMany jsdocs

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -264,13 +264,13 @@ const BookshelfModel = ModelBase.extend({
    * @param {string=} foreignKey
    *
    *   Foreign key in this model. By default, the `foreignKey` is assumed to
-   *   be the singular form of the `Target` model's tableName, followed by `_id` /
+   *   be the singular form of this model's tableName, followed by `_id` /
    *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
    * @param {string=} otherKey
    *
    *   Foreign key in the `Target` model. By default, the `otherKey` is assumed to
-   *   be the singular form of this model's tableName, followed by `_id` /
+   *   be the singular form of the `Target` model's tableName, followed by `_id` /
    *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
    * @returns {Collection}


### PR DESCRIPTION
Current specification of belongsToMany has a bug. Its `otherKey` and `foreignKey` parameter description are mistakenly partially swapped.

Many issues have come up because of this problem. eg. #397, #1031, #1276