### PR TITLE
Add NodeJS v6 support in the TravisCI tests suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ node_js:
   - '0.10'
   - '0.12'
   - '4'
+  - '6'
 
 before_script:
   - psql -c 'create database bookshelf_test;' -U postgres


### PR DESCRIPTION
It's necessary to check if Bookshelf runs OK on NodeJS v6 .