### PR TITLE
Allow changing the knex instance used by bookshelf

### DIFF
--- a/src/bookshelf.js
+++ b/src/bookshelf.js
@@ -285,9 +285,9 @@ function Bookshelf(knex) {
     let builder = null;
 
     if (isString(tableNameOrBuilder)) {
-      builder = knex(tableNameOrBuilder);
+      builder = bookshelf.knex(tableNameOrBuilder);
     } else if (tableNameOrBuilder == null) {
-      builder = knex.queryBuilder();
+      builder = bookshelf.knex.queryBuilder();
     } else {
       // Assuming here that `tableNameOrBuilder` is a QueryBuilder instance. Not
       // aware of a way to check that this is the case (ie. using


### PR DESCRIPTION
This change allows swapping out the underlying `knex` instance after bookshelf has been initialized.  This helps to help completely separate `knex` away from the bookshelf model instances.  

This allows initializing the model object before requiring a database connection.

Eventually, this could allow for a 'connect' method like:

```js
bookshelf.connect = function(config) {
  let oldKnex = this.knex;
  this.knex = new Knex(config);
  oldKnex.destroy().then(function() {
    return bookshelf;
  });
};
```