### PR TITLE
Add foreignKeyTarget to relation methods

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -43,9 +43,37 @@ const BookshelfCollection = CollectionBase.extend({
    * @description
    * Used to define passthrough relationships - `hasOne`, `hasMany`, `belongsTo`
    * or `belongsToMany`, "through" an `Interim` model or collection.
+   *
+   * @param {Model} Interim Pivot model.
+   *
+   * @param {string=} throughForeignKey
+   *
+   *   Foreign key in this collection model. By default, the `foreignKey` is assumed to
+   *   be the singular form of the `Target` model's tableName, followed by `_id` /
+   *   `_{{{@link Model#idAttribute idAttribute}}}`.
+   *
+   * @param {string=} otherKey
+   *
+   *   Foreign key in the `Interim` model. By default, the `otherKey` is assumed to
+   *   be the singular form of this model's tableName, followed by `_id` /
+   *   `_{{{@link Model#idAttribute idAttribute}}}`.
+   *
+   * @param {string=} throughForeignKeyTarget
+   *
+   *   Column in the `Target` model which `throughForeignKey` references, if other
+   *   than `Target` model's `id` / `{@link Model#idAttribute idAttribute}`.
+   *
+   * @param {string=} otherKeyTarget
+   *
+   *   Column in this collection model which `otherKey` references, if other
+   *   than `id` / `{@link Model#idAttribute idAttribute}`.
+   *
+   * @returns {Collection}
    */
-  through: function(Interim, foreignKey, otherKey) {
-    return this.relatedData.through(this, Interim, {throughForeignKey: foreignKey, otherKey: otherKey});
+  through: function(Interim, throughForeignKey, otherKey, throughForeignKeyTarget, otherKeyTarget) {
+    return this.relatedData.through(this, Interim, {
+      throughForeignKey, otherKey, throughForeignKeyTarget, otherKeyTarget
+    });
   },
 
   /**

--- a/src/model.js
+++ b/src/model.js
@@ -99,10 +99,15 @@ const BookshelfModel = ModelBase.extend({
    *   be the singular form of this model's {@link Model#tableName tableName},
    *   followed by `_id` / `_{{{@link Model#idAttribute idAttribute}}}`.
    *
+   * @param {string=} foreignKeyTarget
+   *
+   *   Column in the `Target` model's table which `foreignKey` references, if other
+   *   than `Target` model's `id` / `{@link Model#idAttribute idAttribute}`.
+   *
    * @returns {Model}
    */
-  hasOne(Target, foreignKey) {
-    return this._relation('hasOne', Target, {foreignKey}).init(this);
+  hasOne(Target, foreignKey, foreignKeyTarget) {
+    return this._relation('hasOne', Target, { foreignKey, foreignKeyTarget }).init(this);
   },
 
   /**
@@ -134,10 +139,15 @@ const BookshelfModel = ModelBase.extend({
    *   be the singular form of this model's tableName, followed by `_id` /
    *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
+   * @param {string=} foreignKeyTarget
+   *
+   *   Column in the `Target` model's table which `foreignKey` references, if other
+   *   than `Target` model's `id` / `{@link Model#idAttribute idAttribute}`.
+   *
    * @returns {Collection}
    */
-  hasMany(Target, foreignKey) {
-    return this._relation('hasMany', Target, {foreignKey}).init(this);
+  hasMany(Target, foreignKey, foreignKeyTarget) {
+    return this._relation('hasMany', Target, { foreignKey, foreignKeyTarget }).init(this);
   },
 
   /**
@@ -177,10 +187,15 @@ const BookshelfModel = ModelBase.extend({
    *   be the singular form of the `Target` model's tableName, followed by `_id` /
    *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
+   * @param {string=} foreignKeyTarget
+   *
+   *   Column in the `Target` model's table which `foreignKey` references, if other
+   *   than `Target` model's `id` / `{@link Model#idAttribute idAttribute}`.
+   *
    * @returns {Model}
    */
-  belongsTo(Target, foreignKey) {
-    return this._relation('belongsTo', Target, {foreignKey}).init(this);
+  belongsTo(Target, foreignKey, foreignKeyTarget) {
+    return this._relation('belongsTo', Target, { foreignKey, foreignKeyTarget }).init(this);
   },
 
   /**
@@ -273,11 +288,21 @@ const BookshelfModel = ModelBase.extend({
    *   be the singular form of the `Target` model's tableName, followed by `_id` /
    *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
+   * @param {string=} foreignKeyTarget
+   *
+   *   Column in this model's table which `foreignKey` references, if other
+   *   than `id` / `{@link Model#idAttribute idAttribute}`.
+   *
+   * @param {string=} otherKeyTarget
+   *
+   *   Column in the `Target` model's table which `otherKey` references, if other
+   *   than `Target` model's `id` / `{@link Model#idAttribute idAttribute}`.
+   *
    * @returns {Collection}
    */
-  belongsToMany(Target, joinTableName, foreignKey, otherKey) {
+  belongsToMany(Target, joinTableName, foreignKey, otherKey, foreignKeyTarget, otherKeyTarget) {
     return this._relation('belongsToMany', Target, {
-      joinTableName, foreignKey, otherKey
+      joinTableName, foreignKey, otherKey, foreignKeyTarget, otherKeyTarget
     }).init(this);
   },
 
@@ -496,10 +521,22 @@ const BookshelfModel = ModelBase.extend({
    *   be the singular form of this model's tableName, followed by `_id` /
    *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
+   * @param {string=} throughForeignKeyTarget
+   *
+   *   Column in the `Target` model which `throughForeignKey` references, if other
+   *   than `Target` model's `id` / `{@link Model#idAttribute idAttribute}`.
+   *
+   * @param {string=} otherKeyTarget
+   *
+   *   Column in this model which `otherKey` references, if other
+   *   than `id` / `{@link Model#idAttribute idAttribute}`.
+   *
    * @returns {Collection}
    */
-  through(Interim, throughForeignKey, otherKey) {
-    return this.relatedData.through(this, Interim, {throughForeignKey: throughForeignKey, otherKey: otherKey});
+  through(Interim, throughForeignKey, otherKey, throughForeignKeyTarget, otherKeyTarget) {
+    return this.relatedData.through(this, Interim, {
+      throughForeignKey, otherKey, throughForeignKeyTarget, otherKeyTarget
+    });
   },
 
   /**

--- a/src/relation.js
+++ b/src/relation.js
@@ -21,24 +21,21 @@ export default RelationBase.extend({
   init: function(parent) {
     this.parentId          = parent.id;
     this.parentTableName   = _.result(parent, 'tableName');
-    this.parentIdAttribute = _.result(parent, 'idAttribute');
+    this.parentIdAttribute = this.attribute('parentIdAttribute', parent);
 
-    if (this.isInverse()) {
-      // use formatted attributes so that morphKey and foreignKey will match
-      // attribute keys
-      const attributes = parent.format(_.clone(parent.attributes));
+    // Use formatted attributes so that morphKey and foreignKey will match
+    // attribute keys.
+    this.parentAttributes = parent.format(_.clone(parent.attributes));
 
+    if (this.type === 'morphTo' && !parent._isEager) {
       // If the parent object is eager loading, and it's a polymorphic `morphTo` relation,
       // we can't know what the target will be until the models are sorted and matched.
-      if (this.type === 'morphTo' && !parent._isEager) {
-        this.target = Helpers.morphCandidate(this.candidates, attributes[this.key('morphKey')]);
-        this.targetTableName   = _.result(this.target.prototype, 'tableName');
-        this.targetIdAttribute = _.result(this.target.prototype, 'idAttribute');
-      }
-      this.parentFk = attributes[this.key('foreignKey')];
-    } else {
-      this.parentFk = parent.id;
+      this.target = Helpers.morphCandidate(this.candidates, this.parentAttributes[this.key('morphKey')]);
+      this.targetTableName   = _.result(this.target.prototype, 'tableName');
     }
+
+    this.targetIdAttribute = this.attribute('targetIdAttribute', parent);
+    this.parentFk = this.attribute('parentFk');
 
     const target = this.target ? this.relatedInstance() : {};
         target.relatedData = this;
@@ -60,19 +57,20 @@ export default RelationBase.extend({
 
     this.throughTarget = Target;
     this.throughTableName = _.result(Target.prototype, 'tableName');
-    this.throughIdAttribute = _.result(Target.prototype, 'idAttribute');
-
-    // Set the parentFk as appropriate now.
-    if (this.type === 'belongsTo') {
-      this.parentFk = this.parentId;
-    }
 
     _.extend(this, options);
     _.extend(source, pivotHelpers);
 
+    this.parentIdAttribute = this.attribute('parentIdAttribute');
+    this.targetIdAttribute = this.attribute('targetIdAttribute');
+    this.throughIdAttribute = this.attribute('throughIdAttribute', Target);
+    this.parentFk = this.attribute('parentFk');
+
     // Set the appropriate foreign key if we're doing a belongsToMany, for convenience.
     if (this.type === 'belongsToMany') {
       this.foreignKey = this.throughForeignKey;
+    } else if (this.otherKey) {
+      this.foreignKey = this.otherKey;
     }
 
     return source;
@@ -122,6 +120,91 @@ export default RelationBase.extend({
         break;
     }
     return this[keyName]
+  },
+
+  // Get the correct value for the following attributes:
+  // parentIdAttribute, targetIdAttribute, throughIdAttribute and parentFk.
+  attribute(attribute, parent) {
+    switch (attribute) {
+      case 'parentIdAttribute':
+        if (this.isThrough()) {
+          if (this.type === 'belongsTo' && this.throughForeignKey) {
+            return this.throughForeignKey;
+          }
+
+          if (this.type === 'belongsToMany' && this.isThroughForeignKeyTargeted()) {
+            return this.throughForeignKeyTarget;
+          }
+
+          if (this.isOtherKeyTargeted()) {
+            return this.otherKeyTarget;
+          }
+
+          // Return attribute calculated on `init` by default.
+          return this.parentIdAttribute;
+        }
+
+        if (this.isForeignKeyTargeted()) {
+          return this.foreignKeyTarget;
+        }
+
+        return _.result(parent, 'idAttribute');
+
+      case 'targetIdAttribute':
+        if (this.isThrough()) {
+          if ((this.type === 'belongsToMany' || this.type === 'belongsTo') && this.isOtherKeyTargeted()) {
+            return this.otherKeyTarget;
+          }
+
+          // Return attribute calculated on `init` by default.
+          return this.targetIdAttribute;
+        }
+
+        if (this.type === 'morphTo' && !parent._isEager) {
+          return _.result(this.target.prototype, 'idAttribute');
+        }
+
+        if (this.type === 'belongsTo' && this.isForeignKeyTargeted()) {
+          return this.foreignKeyTarget;
+        }
+
+        if (this.type === 'belongsToMany' && this.isOtherKeyTargeted()) {
+          return this.otherKeyTarget;
+        }
+
+        return this.targetIdAttribute;
+
+      case 'throughIdAttribute':
+        if (this.type !== 'belongsToMany' && this.isThroughForeignKeyTargeted()) {
+          return this.throughForeignKeyTarget;
+        }
+
+        if (this.type === 'belongsToMany' && this.throughForeignKey) {
+          return this.throughForeignKey;
+        }
+
+        return _.result(parent.prototype, 'idAttribute');
+
+      case 'parentFk':
+        if (this.isThrough()) {
+          if (this.type === 'belongsToMany' && this.isThroughForeignKeyTargeted()) {
+            return this.parentAttributes[this.throughForeignKeyTarget];
+          }
+
+          if (this.type === 'belongsTo') {
+            return this.throughForeignKey ? this.parentAttributes[this.parentIdAttribute] : this.parentId;
+          }
+
+          if (this.isOtherKeyTargeted()) {
+            return this.parentAttributes[this.otherKeyTarget];
+          }
+
+          // Return attribute calculated on `init` by default.
+          return this.parentFk;
+        }
+
+        return this.parentAttributes[this.isInverse() ? this.key('foreignKey') : this.parentIdAttribute];
+    }
   },
 
   // Injects the necessary `select` constraints into a `knex` query builder.
@@ -293,11 +376,18 @@ export default RelationBase.extend({
     // Group all of the related models for easier association with their parent models.
     const grouped = _.groupBy(related, (m) => {
       if (m.pivot) {
-        return this.isInverse() && this.isThrough() ? m.pivot.id :
-          m.pivot.get(this.key('foreignKey'));
-      } else {
-        return this.isInverse() ? m.id : m.get(this.key('foreignKey'));
+        if (this.isInverse() && this.isThrough()) {
+          return this.isThroughForeignKeyTargeted() ? m.pivot.get(this.throughForeignKeyTarget) : m.pivot.id;
+        }
+
+        return m.pivot.get(this.key('foreignKey'));
       }
+
+      if (this.isInverse()) {
+        return this.isForeignKeyTargeted() ? m.get(this.foreignKeyTarget) : m.id;
+      }
+
+      return m.get(this.key('foreignKey'));
     });
 
     // Loop over the `parentModels` and attach the grouped sub-models,
@@ -305,7 +395,7 @@ export default RelationBase.extend({
     _.each(parentModels, (model) => {
       let groupedKey;
       if (!this.isInverse()) {
-        groupedKey = model.id;
+        groupedKey = model.get(this.parentIdAttribute);
       } else {
         const keyColumn = this.key(
           this.isThrough() ? 'throughForeignKey': 'foreignKey'
@@ -373,6 +463,15 @@ export default RelationBase.extend({
   },
   isInverse: function() {
     return (this.type === 'belongsTo' || this.type === 'morphTo');
+  },
+  isForeignKeyTargeted() {
+    return this.foreignKeyTarget != null;
+  },
+  isThroughForeignKeyTargeted() {
+    return this.throughForeignKeyTarget != null;
+  },
+  isOtherKeyTargeted() {
+    return this.otherKeyTarget != null;
   },
 
   // Sets the `pivotColumns` to be retrieved along with the current model.

--- a/test/integration/helpers/inserts.js
+++ b/test/integration/helpers/inserts.js
@@ -244,7 +244,18 @@ module.exports = function(bookshelf) {
 
     knex('parsed_users').insert({id: 10, name: 'test'}),
 
-    knex('tokens').insert({parsed_user_id: 10, token: 'testing'})
+    knex('tokens').insert({parsed_user_id: 10, token: 'testing'}),
+
+    knex('locales').insert([
+      { isoCode: 'en' },
+      { isoCode: 'pt' }
+    ]),
+
+    knex('translations').insert([
+      { code: 'en', customer: 'Customer1' },
+      { code: 'en', customer: 'Customer2' },
+      { code: 'pt', customer: 'Customer1' }
+    ])
 
   ]).then(null, function(e) {
     console.log(e.stack);

--- a/test/integration/helpers/migration.js
+++ b/test/integration/helpers/migration.js
@@ -8,7 +8,8 @@ var drops = [
   'users', 'roles', 'photos', 'users_roles', 'info',
   'Customer', 'Settings', 'hostnames', 'instances', 'uuid_test',
   'parsed_users', 'tokens', 'thumbnails',
-  'lefts', 'rights', 'lefts_rights', 'organization'
+  'lefts', 'rights', 'lefts_rights', 'organization',
+  'locales', 'translations'
 ];
 
 module.exports = function(Bookshelf) {
@@ -163,8 +164,14 @@ module.exports = function(Bookshelf) {
       table.increments('organization_id');
       table.string('organization_name').notNullable();
       table.boolean('organization_is_active').defaultTo(false);
-    });
-
+    })
+    .createTable('locales', function(table) {
+      table.string('isoCode');
+    })
+    .createTable('translations', function(table) {
+      table.string('code');
+      table.string('customer');
+    })
   });
 
 };

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -243,6 +243,12 @@ module.exports = function(Bookshelf) {
     tableName: 'Customer',
     settings: function () {
       return this.hasOne(Settings);
+    },
+    locale: function() {
+      return this.hasOne(Locale).through(Translation, 'isoCode', 'customer', 'code', 'name');
+    },
+    locales: function() {
+      return this.hasMany(Locale).through(Translation, 'isoCode', 'customer', 'code', 'name');
     }
   });
 
@@ -349,6 +355,32 @@ module.exports = function(Bookshelf) {
     }
   });
 
+  var Translation = Bookshelf.Model.extend({
+    tableName: 'translations',
+    locale: function() {
+      return this.belongsTo(Locale, 'code', 'isoCode');
+    }
+  });
+
+  var Locale = Bookshelf.Model.extend({
+    tableName: 'locales',
+    customer: function() {
+      return this.belongsTo(Customer).through(Translation, 'isoCode', 'customer', 'code', 'name');
+    },
+    customers: function() {
+      return this.belongsToMany(Customer, 'translations', 'code', 'customer', 'isoCode', 'name');
+    },
+    customersThrough: function() {
+      return this.belongsToMany(Customer).through(Translation, 'code', 'customer', 'isoCode', 'name');
+    },
+    translation: function() {
+      return this.hasOne(Translation, 'code', 'isoCode');
+    },
+    translations: function() {
+      return this.hasMany(Translation, 'code', 'isoCode');
+    }
+  });
+
   return {
     Models: {
       Site: Site,
@@ -378,7 +410,9 @@ module.exports = function(Bookshelf) {
       LeftModel: LeftModel,
       RightModel: RightModel,
       JoinModel: JoinModel,
-      OrgModel: OrgModel
+      OrgModel: OrgModel,
+      Locale: Locale,
+      Translation: Translation
     }
   };
 

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -3558,7 +3558,6 @@ module.exports = {
           id: 1,
           site_id: 1,
           name: 'Main Site Blog',
-          _pivot_id: 1,
           _pivot_owner_id: 1,
           _pivot_blog_id: 1
         }]
@@ -3571,14 +3570,12 @@ module.exports = {
           id: 1,
           site_id: 1,
           name: 'Main Site Blog',
-          _pivot_id: 3,
           _pivot_owner_id: 2,
           _pivot_blog_id: 1
         },{
           id: 2,
           site_id: 1,
           name: 'Alternate Site Blog',
-          _pivot_id: 2,
           _pivot_owner_id: 2,
           _pivot_blog_id: 2
         }]
@@ -3591,7 +3588,6 @@ module.exports = {
           id: 3,
           site_id: 2,
           name: 'Main Site Blog',
-          _pivot_id: 4,
           _pivot_owner_id: 3,
           _pivot_blog_id: 3
         }]
@@ -3604,7 +3600,6 @@ module.exports = {
           id: 4,
           site_id: 2,
           name: 'Alternate Site Blog',
-          _pivot_id: 5,
           _pivot_owner_id: 4,
           _pivot_blog_id: 4
         }]
@@ -3626,7 +3621,6 @@ module.exports = {
           id: 1,
           site_id: 1,
           name: 'Main Site Blog',
-          _pivot_id: 1,
           _pivot_owner_id: 1,
           _pivot_blog_id: 1
         }]
@@ -3639,14 +3633,12 @@ module.exports = {
           id: 1,
           site_id: 1,
           name: 'Main Site Blog',
-          _pivot_id: 3,
           _pivot_owner_id: 2,
           _pivot_blog_id: 1
         },{
           id: 2,
           site_id: 1,
           name: 'Alternate Site Blog',
-          _pivot_id: 2,
           _pivot_owner_id: 2,
           _pivot_blog_id: 2
         }]
@@ -3659,7 +3651,6 @@ module.exports = {
           id: 3,
           site_id: 2,
           name: 'Main Site Blog',
-          _pivot_id: 4,
           _pivot_owner_id: 3,
           _pivot_blog_id: 3
         }]
@@ -3672,7 +3663,6 @@ module.exports = {
           id: 4,
           site_id: 2,
           name: 'Alternate Site Blog',
-          _pivot_id: 5,
           _pivot_owner_id: 4,
           _pivot_blog_id: 4
         }]
@@ -3694,7 +3684,6 @@ module.exports = {
           id: 1,
           site_id: 1,
           name: 'Main Site Blog',
-          _pivot_id: 1,
           _pivot_owner_id: 1,
           _pivot_blog_id: 1
         }]
@@ -3707,14 +3696,12 @@ module.exports = {
           id: 2,
           site_id: 1,
           name: 'Alternate Site Blog',
-          _pivot_id: 2,
           _pivot_owner_id: 2,
           _pivot_blog_id: 2
         },{
           id: 1,
           site_id: 1,
           name: 'Main Site Blog',
-          _pivot_id: 3,
           _pivot_owner_id: 2,
           _pivot_blog_id: 1
         }]
@@ -3727,7 +3714,6 @@ module.exports = {
           id: 3,
           site_id: 2,
           name: 'Main Site Blog',
-          _pivot_id: 4,
           _pivot_owner_id: 3,
           _pivot_blog_id: 3
         }]
@@ -3740,7 +3726,6 @@ module.exports = {
           id: 4,
           site_id: 2,
           name: 'Alternate Site Blog',
-          _pivot_id: 5,
           _pivot_owner_id: 4,
           _pivot_blog_id: 4
         }]
@@ -4185,6 +4170,551 @@ module.exports = {
 
         }
       }]
+    }
+  },
+  "works with hasOne relation (locale -> translation)": {
+    mysql: {
+      result: {
+        code: 'pt',
+        customer: 'Customer1'
+      }
+    },
+    postgresql: {
+      result: {
+        code: 'pt',
+        customer: 'Customer1'
+      }
+    },
+    sqlite3: {
+      result: {
+        code: 'pt',
+        customer: 'Customer1'
+      }
+    }
+  },
+  "works with eager loaded hasOne relation (locale -> translation)": {
+    mysql: {
+      result: {
+        isoCode: 'pt',
+        translation: {
+          code: 'pt',
+          customer: 'Customer1'
+        }
+      }
+    },
+    postgresql: {
+      result: {
+        isoCode: 'pt',
+        translation: {
+          code: 'pt',
+          customer: 'Customer1'
+        }
+      }
+    },
+    sqlite3: {
+      result: {
+        isoCode: 'pt',
+        translation: {
+          code: 'pt',
+          customer: 'Customer1'
+        }
+      }
+    }
+  },
+  "works with hasMany relation (locale -> translations)": {
+    mysql: {
+      result: [{
+        code: 'en',
+        customer: 'Customer1'
+      }, {
+        code: 'en',
+        customer: 'Customer2'
+      }]
+    },
+    postgresql: {
+      result: [{
+        code: 'en',
+        customer: 'Customer1'
+      }, {
+        code: 'en',
+        customer: 'Customer2'
+      }]
+    },
+    sqlite3: {
+      result: [{
+        code: 'en',
+        customer: 'Customer1'
+      }, {
+        code: 'en',
+        customer: 'Customer2'
+      }]
+    }
+  },
+  "works with eager loaded hasMany relation (locale -> translations)": {
+    mysql: {
+      result: {
+        isoCode: 'en',
+        translations: [{
+          code: 'en',
+          customer: 'Customer1'
+        }, {
+          code: 'en',
+          customer: 'Customer2'
+        }]
+      }
+    },
+    postgresql: {
+      result: {
+        isoCode: 'en',
+        translations: [{
+          code: 'en',
+          customer: 'Customer1'
+        }, {
+          code: 'en',
+          customer: 'Customer2'
+        }]
+      }
+    },
+    sqlite3: {
+      result: {
+        isoCode: 'en',
+        translations: [{
+          code: 'en',
+          customer: 'Customer1'
+        }, {
+          code: 'en',
+          customer: 'Customer2'
+        }]
+      }
+    }
+  },
+  "works with belongsTo relation (translation -> locale)": {
+    mysql: {
+      result: {
+        isoCode: 'pt'
+      }
+    },
+    postgresql: {
+      result: {
+        isoCode: 'pt'
+      }
+    },
+    sqlite3: {
+      result: {
+        isoCode: 'pt'
+      }
+    }
+  },
+  "works with eager loaded belongsTo relation (translation -> locale)": {
+    mysql: {
+      result: {
+        code: 'pt',
+        customer: 'Customer1',
+        locale: {
+          isoCode: 'pt'
+        }
+      }
+    },
+    postgresql: {
+      result: {
+        code: 'pt',
+        customer: 'Customer1',
+        locale: {
+          isoCode: 'pt'
+        }
+      }
+    },
+    sqlite3: {
+      result: {
+        code: 'pt',
+        customer: 'Customer1',
+        locale: {
+          isoCode: 'pt'
+        }
+      }
+    }
+  },
+  "works with belongsToMany relation (locale -> customers)": {
+    mysql: {
+      result: [{
+        id: 1,
+        name: 'Customer1',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer1'
+      }, {
+        id: 2,
+        name: 'Customer2',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer2'
+      }]
+    },
+    postgresql: {
+      result: [{
+        id: 1,
+        name: 'Customer1',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer1'
+      }, {
+        id: 2,
+        name: 'Customer2',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer2'
+      }]
+    },
+    sqlite3: {
+      result: [{
+        id: 1,
+        name: 'Customer1',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer1'
+      }, {
+        id: 2,
+        name: 'Customer2',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer2'
+      }]
+    }
+  },
+  "works with eager loaded belongsToMany relation (locale -> customers)": {
+    mysql: {
+      result: {
+        isoCode: 'en',
+        customers: [{
+          id: 1,
+          name: 'Customer1',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer1'
+        }, {
+          id: 2,
+          name: 'Customer2',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer2'
+        }]
+      }
+    },
+    postgresql: {
+      result: {
+        isoCode: 'en',
+        customers: [{
+          id: 1,
+          name: 'Customer1',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer1'
+        }, {
+          id: 2,
+          name: 'Customer2',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer2'
+        }]
+      }
+    },
+    sqlite3: {
+      result: {
+        isoCode: 'en',
+        customers: [{
+          id: 1,
+          name: 'Customer1',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer1'
+        }, {
+          id: 2,
+          name: 'Customer2',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer2'
+        }]
+      }
+    }
+  },
+  "works with hasOne `through` relation (customer -> locale)": {
+    mysql: {
+      result: {
+        isoCode: 'en',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer2'
+      }
+    },
+    postgresql: {
+      result: {
+        isoCode: 'en',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer2'
+      }
+    },
+    sqlite3: {
+      result: {
+        isoCode: 'en',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer2'
+      }
+    }
+  },
+  "works with eager loaded hasOne `through` relation (customer -> locale)": {
+    mysql: {
+      result: {
+        id: 2,
+        name: 'Customer2',
+        locale: {
+          isoCode: 'en',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer2'
+        }
+      }
+    },
+    postgresql: {
+      result: {
+        id: 2,
+        name: 'Customer2',
+        locale: {
+          isoCode: 'en',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer2'
+        }
+      }
+    },
+    sqlite3: {
+      result: {
+        id: 2,
+        name: 'Customer2',
+        locale: {
+          isoCode: 'en',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer2'
+        }
+      }
+    }
+  },
+  "works with hasMany `through` relation (customer -> locales)": {
+    mysql: {
+      result: [{
+        isoCode: 'en',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer1'
+      }, {
+        isoCode: 'pt',
+        _pivot_code: 'pt',
+        _pivot_customer: 'Customer1'
+      }]
+    },
+    postgresql: {
+      result: [{
+        isoCode: 'en',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer1'
+      }, {
+        isoCode: 'pt',
+        _pivot_code: 'pt',
+        _pivot_customer: 'Customer1'
+      }]
+    },
+    sqlite3: {
+      result: [{
+        isoCode: 'en',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer1'
+      }, {
+        isoCode: 'pt',
+        _pivot_code: 'pt',
+        _pivot_customer: 'Customer1'
+      }]
+    }
+  },
+  "works with eager loaded hasMany `through` relation (customer -> locales)": {
+    mysql: {
+      result: {
+        id: 1,
+        name: 'Customer1',
+        locales: [{
+          isoCode: 'en',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer1'
+        }, {
+          isoCode: 'pt',
+          _pivot_code: 'pt',
+          _pivot_customer: 'Customer1'
+        }]
+      }
+    },
+    postgresql: {
+      result: {
+        id: 1,
+        name: 'Customer1',
+        locales: [{
+          isoCode: 'en',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer1'
+        }, {
+          isoCode: 'pt',
+          _pivot_code: 'pt',
+          _pivot_customer: 'Customer1'
+        }]
+      }
+    },
+    sqlite3: {
+      result: {
+        id: 1,
+        name: 'Customer1',
+        locales: [{
+          isoCode: 'en',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer1'
+        }, {
+          isoCode: 'pt',
+          _pivot_code: 'pt',
+          _pivot_customer: 'Customer1'
+        }]
+      }
+    }
+  },
+  "works with belongsTo `through` relation (locale -> customer)": {
+    mysql: {
+      result: {
+        id: 1,
+        name: 'Customer1',
+        _pivot_code: 'pt',
+        _pivot_customer: 'Customer1'
+      }
+    },
+    postgresql: {
+      result: {
+        id: 1,
+        name: 'Customer1',
+        _pivot_code: 'pt',
+        _pivot_customer: 'Customer1'
+      }
+    },
+    sqlite3: {
+      result: {
+        id: 1,
+        name: 'Customer1',
+        _pivot_code: 'pt',
+        _pivot_customer: 'Customer1'
+      }
+    }
+  },
+  "works with eager loaded belongsTo `through` relation (locale -> customer)": {
+    mysql: {
+      result: {
+        isoCode: 'pt',
+        customer: {
+          id: 1,
+          name: 'Customer1',
+          _pivot_code: 'pt',
+          _pivot_customer: 'Customer1'
+        }
+      }
+    },
+    postgresql: {
+      result: {
+        isoCode: 'pt',
+        customer: {
+          id: 1,
+          name: 'Customer1',
+          _pivot_code: 'pt',
+          _pivot_customer: 'Customer1'
+        }
+      }
+    },
+    sqlite3: {
+      result: {
+        isoCode: 'pt',
+        customer: {
+          id: 1,
+          name: 'Customer1',
+          _pivot_code: 'pt',
+          _pivot_customer: 'Customer1'
+        }
+      }
+    }
+  },
+  "works with belongsToMany `through` relation (locale -> customers)": {
+    mysql: {
+      result: [{
+        id: 1,
+        name: 'Customer1',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer1'
+      }, {
+        id: 2,
+        name: 'Customer2',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer2'
+      }]
+    },
+    postgresql: {
+      result: [{
+        id: 1,
+        name: 'Customer1',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer1'
+      }, {
+        id: 2,
+        name: 'Customer2',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer2'
+      }]
+    },
+    sqlite3: {
+      result: [{
+        id: 1,
+        name: 'Customer1',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer1'
+      }, {
+        id: 2,
+        name: 'Customer2',
+        _pivot_code: 'en',
+        _pivot_customer: 'Customer2'
+      }]
+    }
+  },
+  "works with eager belongsToMany `through` relation (locale -> customers)": {
+    mysql: {
+      result: {
+        isoCode: 'en',
+        customersThrough: [{
+          id: 1,
+          name: 'Customer1',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer1'
+        }, {
+          id: 2,
+          name: 'Customer2',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer2'
+        }]
+      }
+    },
+    postgresql: {
+      result: {
+        isoCode: 'en',
+        customersThrough: [{
+          id: 1,
+          name: 'Customer1',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer1'
+        }, {
+          id: 2,
+          name: 'Customer2',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer2'
+        }]
+      }
+    },
+    sqlite3: {
+      result: {
+        isoCode: 'en',
+        customersThrough: [{
+          id: 1,
+          name: 'Customer1',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer1'
+        }, {
+          id: 2,
+          name: 'Customer2',
+          _pivot_code: 'en',
+          _pivot_customer: 'Customer2'
+        }]
+      }
     }
   }
 };

--- a/test/integration/relation.js
+++ b/test/integration/relation.js
@@ -75,6 +75,42 @@ module.exports = function(Bookshelf) {
       }
     });
 
+    var Customer = Bookshelf.Model.extend({
+      tableName: 'customers',
+      locale: function() {
+        return this.hasOne(Locale).through(Translation, 'isoCode', 'customer', 'code', 'name');
+      },
+      locales: function() {
+        return this.hasMany(Locale).through(Translation, 'isoCode', 'customer', 'code', 'name');
+      }
+    });
+
+    var Translation = Bookshelf.Model.extend({
+      tableName: 'translations',
+      locale: function() {
+        return this.belongsTo(Locale, 'code', 'isoCode');
+      }
+    });
+
+    var Locale = Bookshelf.Model.extend({
+      tableName: 'locales',
+      customer: function() {
+        return this.belongsTo(Customer).through(Translation, 'isoCode', 'customer', 'code', 'name');
+      },
+      customers: function() {
+        return this.belongsToMany(Customer, 'translations', 'code', 'customer', 'isoCode', 'name');
+      },
+      customersThrough: function() {
+        return this.belongsToMany(Customer).through(Translation, 'code', 'customer', 'isoCode', 'name');
+      },
+      translation: function() {
+        return this.hasOne(Translation, 'code', 'isoCode');
+      },
+      translations: function() {
+        return this.hasMany(Translation, 'code', 'isoCode');
+      }
+    });
+
     describe('Bookshelf.Relation', function() {
 
       it('should not error if the type / target are not specified', function() {
@@ -97,6 +133,7 @@ module.exports = function(Bookshelf) {
         equal(relatedData.targetTableName, 'doctormeta');
         equal(relatedData.targetIdAttribute, 'customId');
         equal(relatedData.foreignKey, 'doctoring_id');
+        equal(relatedData.foreignKeyTarget, undefined);
 
         // Init
         equal(relatedData.parentId, 1);
@@ -122,6 +159,9 @@ module.exports = function(Bookshelf) {
         equal(relatedData.targetTableName, 'account_histories');
         equal(relatedData.targetIdAttribute, 'id');
         equal(relatedData.foreignKey, undefined);
+        equal(relatedData.foreignKeyTarget, undefined);
+        equal(relatedData.otherKey, undefined);
+        equal(relatedData.otherKeyTarget, undefined);
 
         // Init
         equal(relatedData.parentId, 1);
@@ -133,6 +173,8 @@ module.exports = function(Bookshelf) {
         equal(relatedData.throughTarget, Account);
         equal(relatedData.throughTableName, 'accounts');
         equal(relatedData.throughIdAttribute, 'id');
+        equal(relatedData.throughForeignKey, undefined);
+        equal(relatedData.throughForeignKeyTarget, undefined);
 
         // init the select constraints
         relatedData.selectConstraints(_knex, {});
@@ -154,6 +196,9 @@ module.exports = function(Bookshelf) {
         equal(relatedData.targetTableName, 'suppliers');
         equal(relatedData.targetIdAttribute, 'id');
         equal(relatedData.foreignKey, 'supplier_id');
+        equal(relatedData.foreignKeyTarget, undefined);
+        equal(relatedData.otherKey, undefined);
+        equal(relatedData.otherKeyTarget, undefined);
 
         // Init
         equal(relatedData.parentId, 1);
@@ -165,6 +210,8 @@ module.exports = function(Bookshelf) {
         equal(relatedData.throughTarget, Account);
         equal(relatedData.throughTableName, 'accounts');
         equal(relatedData.throughIdAttribute, 'id');
+        equal(relatedData.throughForeignKey, undefined);
+        equal(relatedData.throughForeignKeyTarget, undefined);
 
         // init the select constraints
         relatedData.selectConstraints(_knex, {});
@@ -186,6 +233,9 @@ module.exports = function(Bookshelf) {
         equal(relatedData.targetTableName, 'patients');
         equal(relatedData.targetIdAttribute, 'id');
         equal(relatedData.foreignKey, undefined);
+        equal(relatedData.foreignKeyTarget, undefined);
+        equal(relatedData.otherKey, undefined);
+        equal(relatedData.otherKeyTarget, undefined);
 
         // Init
         equal(relatedData.parentId, 1);
@@ -197,6 +247,8 @@ module.exports = function(Bookshelf) {
         equal(relatedData.throughTarget, Appointment);
         equal(relatedData.throughTableName, 'appointments');
         equal(relatedData.throughIdAttribute, 'id');
+        equal(relatedData.throughForeignKey, undefined);
+        equal(relatedData.throughForeignKeyTarget, undefined);
 
         // init the select constraints
         relatedData.selectConstraints(_knex, {});
@@ -218,6 +270,9 @@ module.exports = function(Bookshelf) {
         equal(relatedData.targetTableName, 'patients');
         equal(relatedData.targetIdAttribute, 'id');
         equal(relatedData.foreignKey, undefined);
+        equal(relatedData.foreignKeyTarget, undefined);
+        equal(relatedData.otherKey, undefined);
+        equal(relatedData.otherKeyTarget, undefined);
 
         // Init
         equal(relatedData.parentId, 1);
@@ -245,6 +300,7 @@ module.exports = function(Bookshelf) {
         equal(relatedData.targetTableName, 'photos');
         equal(relatedData.targetIdAttribute, 'id');
         equal(relatedData.foreignKey, undefined);
+        equal(relatedData.foreignKeyTarget, undefined);
 
         // Init
         equal(relatedData.parentId, 1);
@@ -256,6 +312,262 @@ module.exports = function(Bookshelf) {
         relatedData.selectConstraints(_knex, {});
 
         var sql = "select `photos`.* from `photos` where `photos`.`imageable_id` = 1 and `photos`.`imageable_type` = 'doctors'";
+
+        equal(_knex.toString(), sql);
+      });
+
+      it('should handle a hasOne relation with explicit foreignKeyTarget', function() {
+        var base = new Locale({ isoCode: 'en' });
+        var relation = base.translation();
+        var _knex = relation.query();
+        var relatedData = relation.relatedData;
+
+        // Base
+        equal(relatedData.type, 'hasOne');
+        equal(relatedData.target, Translation);
+        equal(relatedData.targetTableName, 'translations');
+        equal(relatedData.targetIdAttribute, 'id');
+        equal(relatedData.foreignKey, 'code');
+        equal(relatedData.foreignKeyTarget, 'isoCode');
+
+        // Init
+        equal(relatedData.parentId, undefined);
+        equal(relatedData.parentTableName, 'locales');
+        equal(relatedData.parentIdAttribute, 'isoCode');
+        equal(relatedData.parentFk, 'en');
+
+        // init the select constraints
+        relatedData.selectConstraints(_knex, {});
+
+        equal(_knex.toString(), 'select `translations`.* from `translations` where `translations`.`code` = \'en\' limit 1');
+      });
+
+      it('should handle a hasOne -> through relation with explicit foreignKeyTarget', function() {
+        var base = new Customer({ name: 'foobar' });
+        var relation = base.locale();
+        var _knex = relation.query();
+        var relatedData = relation.relatedData;
+
+        // Base
+        equal(relatedData.type, 'hasOne');
+        equal(relatedData.target, Locale);
+        equal(relatedData.targetTableName, 'locales');
+        equal(relatedData.targetIdAttribute, 'id');
+        equal(relatedData.foreignKey, 'customer');
+        equal(relatedData.foreignKeyTarget, undefined);
+        equal(relatedData.otherKey, 'customer');
+        equal(relatedData.otherKeyTarget, 'name');
+
+        // Init
+        equal(relatedData.parentId, undefined);
+        equal(relatedData.parentTableName, 'customers');
+        equal(relatedData.parentIdAttribute, 'name');
+        equal(relatedData.parentFk, 'foobar');
+
+        // Through
+        equal(relatedData.throughTarget, Translation);
+        equal(relatedData.throughTableName, 'translations');
+        equal(relatedData.throughIdAttribute, 'code');
+        equal(relatedData.throughForeignKey, 'isoCode');
+        equal(relatedData.throughForeignKeyTarget, 'code');
+
+        // init the select constraints
+        relatedData.selectConstraints(_knex, {});
+
+        equal(_knex.toString(), 'select `locales`.*, `translations`.`code` as `_pivot_code`, `translations`.`customer` as `_pivot_customer` from `locales` inner join `translations` on `translations`.`code` = `locales`.`isoCode` where `translations`.`customer` = \'foobar\' limit 1');
+      });
+
+      it('should handle a hasMany relation with explicit foreignKeyTarget', function() {
+        var base = new Locale({ isoCode: 'en' });
+        var relation = base.translations();
+        var _knex = relation.query();
+        var relatedData = relation.relatedData;
+
+        // Base
+        equal(relatedData.type, 'hasMany');
+        equal(relatedData.target, Translation);
+        equal(relatedData.targetTableName, 'translations');
+        equal(relatedData.targetIdAttribute, 'id');
+        equal(relatedData.foreignKey, 'code');
+        equal(relatedData.foreignKeyTarget, 'isoCode');
+
+        // Init
+        equal(relatedData.parentId, undefined);
+        equal(relatedData.parentTableName, 'locales');
+        equal(relatedData.parentIdAttribute, 'isoCode');
+        equal(relatedData.parentFk, 'en');
+
+        // init the select constraints
+        relatedData.selectConstraints(_knex, {});
+
+        equal(_knex.toString(), 'select `translations`.* from `translations` where `translations`.`code` = \'en\'');
+      });
+
+      it('should handle a hasMany -> through relation with explicit foreignKeyTarget', function() {
+        var base = new Customer({ name: 'foobar' });
+        var relation = base.locales();
+        var _knex = relation.query();
+        var relatedData = relation.relatedData;
+
+        // Base
+        equal(relatedData.type, 'hasMany');
+        equal(relatedData.target, Locale);
+        equal(relatedData.targetTableName, 'locales');
+        equal(relatedData.targetIdAttribute, 'id');
+        equal(relatedData.foreignKey, 'customer');
+        equal(relatedData.foreignKeyTarget, undefined);
+        equal(relatedData.otherKey, 'customer');
+        equal(relatedData.otherKeyTarget, 'name');
+
+        // Init
+        equal(relatedData.parentId, undefined);
+        equal(relatedData.parentTableName, 'customers');
+        equal(relatedData.parentIdAttribute, 'name');
+        equal(relatedData.parentFk, 'foobar');
+
+        // Through
+        equal(relatedData.throughTarget, Translation);
+        equal(relatedData.throughTableName, 'translations');
+        equal(relatedData.throughIdAttribute, 'code');
+        equal(relatedData.throughForeignKey, 'isoCode');
+        equal(relatedData.throughForeignKeyTarget, 'code');
+
+        // init the select constraints
+        relatedData.selectConstraints(_knex, {});
+
+        equal(_knex.toString(), 'select `locales`.*, `translations`.`code` as `_pivot_code`, `translations`.`customer` as `_pivot_customer` from `locales` inner join `translations` on `translations`.`code` = `locales`.`isoCode` where `translations`.`customer` = \'foobar\'');
+      });
+
+      it('should handle a belongsTo relation with explicit foreignKeyTarget', function() {
+        var base = new Translation({ code: 'en' });
+        var relation = base.locale();
+        var _knex = relation.query();
+        var relatedData = relation.relatedData;
+
+        // Base
+        equal(relatedData.type, 'belongsTo');
+        equal(relatedData.target, Locale);
+        equal(relatedData.targetTableName, 'locales');
+        equal(relatedData.targetIdAttribute, 'isoCode');
+        equal(relatedData.foreignKey, 'code');
+        equal(relatedData.foreignKeyTarget, 'isoCode');
+
+        // Init
+        equal(relatedData.parentId, undefined);
+        equal(relatedData.parentTableName, 'translations');
+        equal(relatedData.parentIdAttribute, 'isoCode');
+        equal(relatedData.parentFk, 'en');
+
+        // init the select constraints
+        relatedData.selectConstraints(_knex, {});
+
+        var sql = 'select `locales`.* from `locales` where `locales`.`isoCode` = \'en\' limit 1';
+
+        equal(_knex.toString(), sql);
+      });
+
+      it('should handle a belongsTo -> through relation with explicit foreignKeyTarget', function() {
+        var base = new Locale({ isoCode: 'en' });
+        var relation = base.customer();
+        var _knex = relation.query();
+        var relatedData = relation.relatedData;
+
+        // Base
+        equal(relatedData.type, 'belongsTo');
+        equal(relatedData.target, Customer);
+        equal(relatedData.targetTableName, 'customers');
+        equal(relatedData.targetIdAttribute, 'name');
+        equal(relatedData.foreignKey, 'customer');
+        equal(relatedData.foreignKeyTarget, undefined);
+        equal(relatedData.otherKey, 'customer');
+        equal(relatedData.otherKeyTarget, 'name');
+
+        // Init
+        equal(relatedData.parentId, undefined);
+        equal(relatedData.parentTableName, 'locales');
+        equal(relatedData.parentIdAttribute, 'isoCode');
+        equal(relatedData.parentFk, 'en');
+
+        // Through
+        equal(relatedData.throughTarget, Translation);
+        equal(relatedData.throughTableName, 'translations');
+        equal(relatedData.throughIdAttribute, 'code');
+        equal(relatedData.throughForeignKey, 'isoCode');
+        equal(relatedData.throughForeignKeyTarget, 'code');
+
+        // init the select constraints
+        relatedData.selectConstraints(_knex, {});
+
+        var sql = 'select `customers`.*, `translations`.`code` as `_pivot_code`, `translations`.`customer` as `_pivot_customer` from `customers` inner join `translations` on `translations`.`customer` = `customers`.`name` inner join `locales` on `translations`.`code` = `locales`.`isoCode` where `locales`.`isoCode` = \'en\' limit 1';
+
+        equal(_knex.toString(), sql);
+      });
+
+      it('should handle a belongsToMany relation with explicit foreignKeyTarget and otherKeyTarget', function() {
+        var base = new Locale({ isoCode: 'en' });
+        var relation = base.customers();
+        var _knex = relation.query();
+        var relatedData = relation.relatedData;
+
+        // Base
+        equal(relatedData.type, 'belongsToMany');
+        equal(relatedData.target, Customer);
+        equal(relatedData.targetTableName, 'customers');
+        equal(relatedData.targetIdAttribute, 'name');
+        equal(relatedData.joinTableName, 'translations');
+        equal(relatedData.foreignKey, 'code');
+        equal(relatedData.foreignKeyTarget, 'isoCode');
+        equal(relatedData.otherKey, 'customer');
+        equal(relatedData.otherKeyTarget, 'name');
+
+        // Init
+        equal(relatedData.parentId, undefined);
+        equal(relatedData.parentTableName, 'locales');
+        equal(relatedData.parentIdAttribute, 'isoCode');
+        equal(relatedData.parentFk, 'en');
+
+        // init the select constraints
+        relatedData.selectConstraints(_knex, {});
+
+        var sql = 'select `customers`.*, `translations`.`code` as `_pivot_code`, `translations`.`customer` as `_pivot_customer` from `customers` inner join `translations` on `translations`.`customer` = `customers`.`name` where `translations`.`code` = \'en\'';
+
+        equal(_knex.toString(), sql);
+      });
+
+      it('should handle a belongsToMany -> through relation with explicit foreignKeyTarget and otherKeyTarget', function() {
+        var base = new Locale({ isoCode: 'en' });
+        var relation = base.customersThrough();
+        var _knex = relation.query();
+        var relatedData = relation.relatedData;
+
+        // Base
+        equal(relatedData.type, 'belongsToMany');
+        equal(relatedData.target, Customer);
+        equal(relatedData.targetTableName, 'customers');
+        equal(relatedData.targetIdAttribute, 'name');
+        equal(relatedData.joinTableName, undefined);
+        equal(relatedData.foreignKey, 'code');
+        equal(relatedData.foreignKeyTarget, undefined);
+        equal(relatedData.otherKey, 'customer');
+        equal(relatedData.otherKeyTarget, 'name');
+
+        // Init
+        equal(relatedData.parentId, undefined);
+        equal(relatedData.parentTableName, 'locales');
+        equal(relatedData.parentIdAttribute, 'isoCode');
+        equal(relatedData.parentFk, 'en');
+
+        // Through
+        equal(relatedData.throughTarget, Translation);
+        equal(relatedData.throughTableName, 'translations');
+        equal(relatedData.throughIdAttribute, 'code');
+        equal(relatedData.throughForeignKey, 'code');
+        equal(relatedData.throughForeignKeyTarget, 'isoCode');
+
+        // init the select constraints
+        relatedData.selectConstraints(_knex, {});
+
+        var sql = 'select `customers`.*, `translations`.`code` as `_pivot_code`, `translations`.`code` as `_pivot_code`, `translations`.`customer` as `_pivot_customer` from `customers` inner join `translations` on `translations`.`customer` = `customers`.`name` where `translations`.`code` = \'en\'';
 
         equal(_knex.toString(), sql);
       });

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -45,6 +45,9 @@ module.exports = function(Bookshelf) {
     var RightModel  = Models.RightModel;
     var JoinModel   = Models.JoinModel;
 
+    var Locale = Models.Locale;
+    var Translation = Models.Translation;
+
     describe('Bookshelf Relations', function() {
 
       describe('Standard Relations - Models', function() {
@@ -1025,6 +1028,114 @@ module.exports = function(Bookshelf) {
           });
         });
       });
+    });
+
+    describe('Issue #1388 - Custom foreignKeyTarget & otherKeyTarget', function() {
+
+      it('works with hasOne relation (locale -> translation)', function() {
+        return new Locale({ isoCode: 'pt' })
+          .translation()
+          .fetch()
+          .then(checkTest(this));
+      });
+
+      it('works with eager loaded hasOne relation (locale -> translation)', function() {
+        return new Locale({ isoCode: 'pt' })
+          .fetch({ withRelated: 'translation' })
+          .then(checkTest(this));
+      });
+
+      it('works with hasOne `through` relation (customer -> locale)', function() {
+        return new Customer({ name: 'Customer2' })
+          .locale()
+          .fetch()
+          .then(checkTest(this));
+      });
+
+      it('works with eager loaded hasOne `through` relation (customer -> locale)', function() {
+        return new Customer({ name: 'Customer2' })
+          .fetch({ withRelated: 'locale' })
+          .then(checkTest(this));
+      });
+
+      it('works with hasMany relation (locale -> translations)', function() {
+        return new Locale({ isoCode: 'en' })
+          .translations()
+          .fetch()
+          .then(checkTest(this));
+      });
+
+      it('works with eager loaded hasMany relation (locale -> translations)', function() {
+        return new Locale({ isoCode: 'en' })
+          .fetch({ withRelated: 'translations' })
+          .then(checkTest(this));
+      });
+
+      it('works with hasMany `through` relation (customer -> locales)', function() {
+        return new Customer({ name: 'Customer1' })
+          .locales()
+          .fetch()
+          .then(checkTest(this));
+      });
+
+      it('works with eager loaded hasMany `through` relation (customer -> locales)', function() {
+        return new Customer({ name: 'Customer1' })
+          .fetch({ withRelated: 'locales' })
+          .then(checkTest(this));
+      });
+
+      it('works with belongsTo relation (translation -> locale)', function() {
+        return new Translation({ code: 'pt' })
+          .locale()
+          .fetch()
+          .then(checkTest(this));
+      });
+
+      it('works with eager loaded belongsTo relation (translation -> locale)', function() {
+        return new Translation({ code: 'pt' })
+          .fetch({ withRelated: 'locale' })
+          .then(checkTest(this));
+      });
+
+      it('works with belongsTo `through` relation (locale -> customer)', function() {
+        return new Locale({ isoCode: 'pt' })
+          .customer()
+          .fetch()
+          .then(checkTest(this));
+      });
+
+      it('works with eager loaded belongsTo `through` relation (locale -> customer)', function() {
+        return new Locale({ isoCode: 'pt' })
+          .fetch({ withRelated: 'customer' })
+          .then(checkTest(this));
+      });
+
+      it('works with belongsToMany relation (locale -> customers)', function() {
+        return new Locale({ isoCode: 'en' })
+          .customers()
+          .fetch()
+          .then(checkTest(this));
+      });
+
+      it('works with eager loaded belongsToMany relation (locale -> customers)', function() {
+        return new Locale({ isoCode: 'en' })
+          .fetch({ withRelated: 'customers' })
+          .then(checkTest(this));
+      });
+
+      it('works with belongsToMany `through` relation (locale -> customers)', function() {
+        return new Locale({ isoCode: 'en' })
+          .customersThrough()
+          .fetch()
+          .then(checkTest(this));
+      });
+
+      it('works with eager belongsToMany `through` relation (locale -> customers)', function() {
+        return new Locale({ isoCode: 'en' })
+          .fetch({ withRelated: 'customersThrough' })
+          .then(checkTest(this));
+      });
+
     });
 
   });


### PR DESCRIPTION
This PR adds `foreignKeyTarget` argument to the relation methods above, in order to specify which column of the target model is referenced by the foreign key:

* `hasOne`
* `hasMany`
* `belongsTo`
* `belongsToMany` (Also adds `otherKeyTarget`)

Closes #1388 
Closes #1407 