### PR TITLE
Move lint from test script to pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "dev": "babel -w -q -L -D ./src/ --out-dir ./lib/",
     "build": "babel -q -L -D ./src/ --out-dir ./lib/",
     "lint": "eslint bookshelf.js src/",
-    "cover": "npm run lint && istanbul cover _mocha -- --check-leaks -t 10000 -b -R spec test/index.js",
-    "test": "npm run lint &&  mocha --check-leaks -t 10000 -b test/index.js",
+    "cover": "istanbul cover _mocha -- --check-leaks -t 10000 -b -R spec test/index.js",
+    "test": "mocha --check-leaks -t 10000 -b test/index.js",
     "jsdoc": "./scripts/jsdoc.sh",
     "gh-pages": "./scripts/gh-pages.sh",
     "prepublish": "npm run build",
@@ -55,6 +55,7 @@
     "mysql": "^2.5.2",
     "node-uuid": "~1.4.1",
     "pg": "^6.1.0",
+    "pre-commit": "^1.1.3",
     "semver": "^5.0.3",
     "sinon": "^1.11.1",
     "sinon-chai": "^2.6.0",
@@ -68,5 +69,8 @@
     "web": "https://github.com/tgriesser"
   },
   "license": "MIT",
-  "readmeFilename": "README.md"
+  "readmeFilename": "README.md",
+  "pre-commit": [
+    "lint"
+  ]
 }


### PR DESCRIPTION
This PR removes `lint` script from both `test` and `coverage` scripts, which is now causing any build to fail on Travis since the current version of **eslint** does not support Node.js versions below v4.0.0.

I guess moving it to a pre-commit hook makes sense, since its purpose it's to avoid commiting (and merge) code with errors or not compliant to the code base.