### PR TITLE
Fix Node 0.10 and 0.12 ESlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gh-pages": "./scripts/gh-pages.sh",
     "prepublish": "npm run build",
     "postpublish": "./scripts/postpublish.sh",
-    "postinstall": "install-engine-dependencies"
+    "postinstall": "node --eval \"if (process.env.NODE_ENV === 'production') process.exit(1);\" && install-engine-dependencies"
   },
   "homepage": "http://bookshelfjs.org",
   "repository": {
@@ -34,7 +34,6 @@
     "bluebird": "^3.4.3",
     "chalk": "^1.0.0",
     "create-error": "~0.3.1",
-    "engine-dependencies": "^0.2.11",
     "inflection": "^1.5.1",
     "inherits": "~2.0.1",
     "lodash": "^4.13.1"
@@ -49,6 +48,7 @@
     "bookshelf-jsdoc-theme": "^0.1.2",
     "chai": "^3.5.0",
     "eslint": "^3.5.0",
+    "engine-dependencies": "^0.2.11",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.0",
     "knex": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "jsdoc": "./scripts/jsdoc.sh",
     "gh-pages": "./scripts/gh-pages.sh",
     "prepublish": "npm run build",
-    "postpublish": "./scripts/postpublish.sh"
+    "postpublish": "./scripts/postpublish.sh",
+    "postinstall": "install-engine-dependencies"
   },
   "homepage": "http://bookshelfjs.org",
   "repository": {
@@ -33,6 +34,7 @@
     "bluebird": "^3.4.3",
     "chalk": "^1.0.0",
     "create-error": "~0.3.1",
+    "engine-dependencies": "^0.2.11",
     "inflection": "^1.5.1",
     "inherits": "~2.0.1",
     "lodash": "^4.13.1"
@@ -59,6 +61,15 @@
     "sinon": "^1.11.1",
     "sinon-chai": "^2.6.0",
     "sqlite3": "^3.0.5"
+  },
+  "engineDependencies": {
+    "node": {
+      "< 4": {
+        "devDependencies": {
+          "eslint": "^2.13.0"
+        }
+      }
+    }
   },
   "peerDependencies": {
     "knex": ">=0.6.10 <0.13.0"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "test": "npm run lint &&  mocha --check-leaks -t 10000 -b test/index.js",
     "jsdoc": "./scripts/jsdoc.sh",
     "gh-pages": "./scripts/gh-pages.sh",
+    "install-engine-dependencies": "install-engine-dependencies",
     "prepublish": "npm run build",
     "postpublish": "./scripts/postpublish.sh",
-    "postinstall": "node --eval \"if (process.env.NODE_ENV === 'production') process.exit(1);\" && install-engine-dependencies && node ./scripts/build.js lib \"npm run build\""
+    "postinstall": "node ./scripts/postinstall.js"
   },
   "homepage": "http://bookshelfjs.org",
   "repository": {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+var child_process = require('child_process');
+var Promise = require('bluebird');
+var isWin = /^win/.test(process.platform);
+
+// This script is only needed to simplify package.json `postinstall` script. 
+//
+// !!! THIS SCRIPT SHOULD BE REMOVED AFTER 2016-12-31 WHEN NODE v0.10.x and !!!
+// !!! v0.12.x MAINTANANCE WILL END                                         !!!
+//
+// After 2016-12-31 change `package.json` `scripts.postinstall` entry to:
+//
+//   "postinstall": "node ./scripts/build.js lib \"npm run build\"",
+//
+
+// Promisify child_process spawn
+
+var spawn = function (cmd, args) {
+  return new Promise(function(resolve, reject) {
+    var child, spawn = child_process.spawn;
+
+    // Execute command for Windows
+    if (isWin) child = spawn('cmd.exe', ['/c', cmd].concat(args), {cwd: process.cwd(), stdio: 'inherit'});
+    // Execute command for other operating systems
+    else child = spawn(cmd, args , {cwd: process.cwd(), stdio: 'inherit'});
+
+    // Pass stdout and stderr
+    // Handle result
+    child.on('exit', function (code) {
+      if (code) reject(code);
+      else resolve();
+    });
+    child.on('error', reject);
+  });
+} 
+
+// Process `postinstall`
+
+Promise.try(function () {
+  // This is required only for non-production env
+  if (process.env.NODE_ENV !== 'production') {
+    // Install babel-eslint ^2.13.0 instead of ^3.5.0 for Node v0.10 and v0.12
+    return spawn('npm', ['run', 'install-engine-dependencies']);
+  }
+}).then(function () {
+  // Run ./scripts/build.js that will compile `lib` folder if its currently not present
+  return spawn('node', ['./scripts/build.js', 'lib', 'npm run build']);
+}).catch(function (err) {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Support Node v0.10.x and v0.12.x until the end of their maintanance.

![Image of NodeJS Lont-Time-Support](https://raw.githubusercontent.com/nodejs/LTS/master/schedule.png)
from https://github.com/nodejs/LTS

Invalidates PR: #1399 #1398