### PR TITLE
Improve Model `defaults` property to be usable for JSON structure

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -904,7 +904,7 @@ const BookshelfModel = ModelBase.extend({
       if (method === 'insert' || options.defaults) {
         const defaults = _.result(this, 'defaults');
         if (defaults) {
-          attrs = _.extend({}, defaults, this.attributes, attrs);
+          attrs = _.defaultsDeep({}, attrs, this.attributes, defaults);
         }
       }
 

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -930,11 +930,11 @@ module.exports = function(bookshelf) {
     describe('defaults', function() {
 
       it('assigns defaults on save, rather than initialize', function() {
-        var Item = bookshelf.Model.extend({defaults: {item: 'test'}});
-        var item = new Item({newItem: 'test2'});
-        deepEqual(item.toJSON(), {newItem: 'test2'});
+        var Item = bookshelf.Model.extend({defaults: {item: 'test', json: {key1: 'defaultValue1', key2: 'defaultValue2'}}});
+        var item = new Item({newItem: 'test2', json: {key1: 'value1'}});
+        deepEqual(item.toJSON(), {newItem: 'test2', json: {key1: 'value1'}});
         item.sync = function() {
-          deepEqual(this.toJSON(), {id: 1, item: 'test', newItem: 'test2'});
+          deepEqual(this.toJSON(), {id: 1, item: 'test', newItem: 'test2', json: {key1: 'value1', key2: 'defaultValue2'}});
           return stubSync;
         };
         return item.save({id: 1});


### PR DESCRIPTION
Currently Model defaults do not work for JSON data type. JSON type needs deep extending. Lodash doesn't have a straight forward method for that. Except [`_.defaultsDeep`](https://lodash.com/docs/4.16.2#defaultsDeep) can be used for that.

Example in tests