### PR TITLE
targetKey option for belongsTo, hasMany, hasOne, belongsToMany (and otherTargetKey)

### DIFF
--- a/src/base/eager.js
+++ b/src/base/eager.js
@@ -45,7 +45,7 @@ _.extend(EagerBase.prototype, {
       // Only allow one of a certain nested type per-level.
       if (handled[relationName]) continue;
 
-      if (!_.isFunction(target[relationName])){
+      if (!_.isFunction(target[relationName])) {
         throw new Error(relationName + ' is not defined on the model.');
       }
 

--- a/src/base/relation.js
+++ b/src/base/relation.js
@@ -1,7 +1,7 @@
 // Base Relation
 // ---------------
 
-import { assign, result } from 'lodash';
+import { assign, result, omitBy, isNil } from 'lodash';
 import CollectionBase from './collection';
 import extend from '../extend';
 
@@ -14,7 +14,7 @@ export default class RelationBase {
       this.targetTableName   = result(Target.prototype, 'tableName');
       this.targetIdAttribute = result(Target.prototype, 'idAttribute');
     }
-    assign(this, { type, target: Target }, options);
+    assign(this, { type, target: Target }, omitBy(options, isNil));
   }
 
   // Creates a new relation instance, used by the `Eager` relation in

--- a/src/model.js
+++ b/src/model.js
@@ -503,8 +503,13 @@ const BookshelfModel = ModelBase.extend({
    *
    * @returns {Collection}
    */
-  through(Interim, throughForeignKey, otherKey) {
-    return this.relatedData.through(this, Interim, {throughForeignKey: throughForeignKey, otherKey: otherKey});
+  through(Interim, throughForeignKey, otherKey, throughTargetKey, otherTargetKey) {
+    return this.relatedData.through(this, Interim, {
+      throughForeignKey,
+      otherKey,
+      throughIdAttribute: throughTargetKey,
+      targetIdAttribute: otherTargetKey
+    });
   },
 
   /**

--- a/src/model.js
+++ b/src/model.js
@@ -101,8 +101,8 @@ const BookshelfModel = ModelBase.extend({
    *
    * @returns {Model}
    */
-  hasOne(Target, foreignKey) {
-    return this._relation('hasOne', Target, {foreignKey}).init(this);
+  hasOne(Target, foreignKey, targetKey) {
+    return this._relation('hasOne', Target, {foreignKey, targetKey}).init(this);
   },
 
   /**
@@ -136,8 +136,8 @@ const BookshelfModel = ModelBase.extend({
    *
    * @returns {Collection}
    */
-  hasMany(Target, foreignKey) {
-    return this._relation('hasMany', Target, {foreignKey}).init(this);
+  hasMany(Target, foreignKey, targetKey) {
+    return this._relation('hasMany', Target, {foreignKey, targetKey}).init(this);
   },
 
   /**
@@ -280,9 +280,9 @@ const BookshelfModel = ModelBase.extend({
    *
    * @returns {Collection}
    */
-  belongsToMany(Target, joinTableName, foreignKey, otherKey) {
+  belongsToMany(Target, joinTableName, foreignKey, otherKey, targetKey, otherTargetKey) {
     return this._relation('belongsToMany', Target, {
-      joinTableName, foreignKey, otherKey
+      joinTableName, foreignKey, otherKey, targetKey, targetIdAttribute: otherTargetKey
     }).init(this);
   },
 

--- a/src/model.js
+++ b/src/model.js
@@ -177,10 +177,15 @@ const BookshelfModel = ModelBase.extend({
    *   be the singular form of the `Target` model's tableName, followed by `_id` /
    *   `_{{{@link Model#idAttribute idAttribute}}}`.
    *
+   * @param {string=} targetKey
+   *
+   *   ForeignKey in the `Target` model. default, the targetKey is assumed to
+   *   be the `idAttribute` of the `Target` model.
+   *
    * @returns {Model}
    */
-  belongsTo(Target, foreignKey) {
-    return this._relation('belongsTo', Target, {foreignKey}).init(this);
+  belongsTo(Target, foreignKey, targetKey) {
+    return this._relation('belongsTo', Target, {foreignKey, targetIdAttribute: targetKey}).init(this);
   },
 
   /**

--- a/src/relation.js
+++ b/src/relation.js
@@ -296,7 +296,8 @@ export default RelationBase.extend({
         return this.isInverse() && this.isThrough() ? m.pivot.id :
           m.pivot.get(this.key('foreignKey'));
       } else {
-        return this.isInverse() ? m.id : m.get(this.key('foreignKey'));
+        return this.isInverse() ? m.get(this.targetIdAttribute) :
+          m.get(this.key('foreignKey'));
       }
     });
 

--- a/src/relation.js
+++ b/src/relation.js
@@ -70,7 +70,7 @@ export default RelationBase.extend({
       this.parentFk = this.parentId;
     }
 
-    _.extend(this, options);
+    _.extend(this, _.omitBy(options, _.isNil));
     _.extend(source, pivotHelpers);
 
     // Set the appropriate foreign key if we're doing a belongsToMany, for convenience.
@@ -296,11 +296,13 @@ export default RelationBase.extend({
     // Group all of the related models for easier association with their parent models.
     const grouped = _.groupBy(related, (m) => {
       if (m.pivot) {
-        return this.isInverse() && this.isThrough() ? m.pivot.id :
-          m.pivot.get(this.key('foreignKey'));
+        return this.isInverse() && this.isThrough()
+          ? m.pivot.get(this.throughIdAttribute)
+          : m.pivot.get(this.key('foreignKey'));
       } else {
-        return this.isInverse() ? m.get(this.targetIdAttribute) :
-          m.get(this.key('foreignKey'));
+        return this.isInverse()
+          ? m.get(this.targetIdAttribute)
+          : m.get(this.key('foreignKey'));
       }
     });
 

--- a/src/relation.js
+++ b/src/relation.js
@@ -37,7 +37,10 @@ export default RelationBase.extend({
       }
       this.parentFk = attributes[this.key('foreignKey')];
     } else {
-      this.parentFk = parent.id;
+      if (this.targetKey) {
+        this.parentIdAttribute = this.targetKey;
+      }
+      this.parentFk = parent.get(this.parentIdAttribute);
     }
 
     const target = this.target ? this.relatedInstance() : {};
@@ -306,7 +309,7 @@ export default RelationBase.extend({
     _.each(parentModels, (model) => {
       let groupedKey;
       if (!this.isInverse()) {
-        groupedKey = model.id;
+        groupedKey = model.get(this.parentIdAttribute);
       } else {
         const keyColumn = this.key(
           this.isThrough() ? 'throughForeignKey': 'foreignKey'

--- a/test/integration/helpers/inserts.js
+++ b/test/integration/helpers/inserts.js
@@ -45,28 +45,28 @@ module.exports = function(bookshelf) {
     knex('countries').insert([{
       language_iso_code: 'es',
       name: 'Venezuela',
-      iso_code: 've'
+      country_iso_code: 've'
     }, {
       language_iso_code: 'es',
       name: 'Colombia',
-      iso_code: 'co'
+      country_iso_code: 'co'
     }, {
       language_iso_code: 'it',
       name: 'Italia',
-      iso_code: 'it'
+      country_iso_code: 'it'
     }]),
 
     knex('cities').insert([{
-      country_iso_code: 've',
+      country_code: 've',
       name: 'Caracas'
     }, {
-      country_iso_code: 'co',
+      country_code: 'co',
       name: 'Bogotá'
     }, {
-      country_iso_code: 'co',
+      country_code: 'co',
       name: 'Medellín'
     }, {
-      country_iso_code: 'it',
+      country_code: 'it',
       name: 'Genova'
     }]),
 

--- a/test/integration/helpers/inserts.js
+++ b/test/integration/helpers/inserts.js
@@ -22,6 +22,14 @@ module.exports = function(bookshelf) {
       description: 'This is a description for the Bookshelfjs Site'
     }]),
 
+    knex('sites_extra').insert([{
+      website_name: 'bookshelfjs.org',
+      extra_description: 'This is the extra description for the Bookshelfjs Site'
+    }, {
+      website_name: 'knexjs.org',
+      extra_description: 'This is the extra description for the Knexjs Site'
+    }]),
+
     knex('info').insert([{
       meta_id: 1,
       other_description: 'This is an info block for hasOne -> through test'

--- a/test/integration/helpers/inserts.js
+++ b/test/integration/helpers/inserts.js
@@ -22,12 +22,52 @@ module.exports = function(bookshelf) {
       description: 'This is a description for the Bookshelfjs Site'
     }]),
 
-    knex('sites_extra').insert([{
+    knex('sites_translations').insert([{
       website_name: 'bookshelfjs.org',
-      extra_description: 'This is the extra description for the Bookshelfjs Site'
+      translated_content: 'Este es el contenido traducido del sitio web de Bookshelfjs',
+      locale_iso: 'es'
     }, {
       website_name: 'knexjs.org',
-      extra_description: 'This is the extra description for the Knexjs Site'
+      translated_content: 'Este es el contenido traducido del sitio web de Knexjs',
+      locale_iso: 'es'
+    }, {
+      website_name: 'bookshelfjs.org',
+      translated_content: 'Questo è il contenuto tradotto del sito di Bookshelfjs',
+      locale_iso: 'it'
+    }]),
+
+    knex('locales').insert([{
+      iso_code: 'es'
+    }, {
+      iso_code: 'it'
+    }]),
+
+    knex('countries').insert([{
+      language_iso_code: 'es',
+      name: 'Venezuela',
+      iso_code: 've'
+    }, {
+      language_iso_code: 'es',
+      name: 'Colombia',
+      iso_code: 'co'
+    }, {
+      language_iso_code: 'it',
+      name: 'Italia',
+      iso_code: 'it'
+    }]),
+
+    knex('cities').insert([{
+      country_iso_code: 've',
+      name: 'Caracas'
+    }, {
+      country_iso_code: 'co',
+      name: 'Bogotá'
+    }, {
+      country_iso_code: 'co',
+      name: 'Medellín'
+    }, {
+      country_iso_code: 'it',
+      name: 'Genova'
     }]),
 
     knex('info').insert([{

--- a/test/integration/helpers/migration.js
+++ b/test/integration/helpers/migration.js
@@ -48,11 +48,11 @@ module.exports = function(Bookshelf) {
       table.increments('id');
       table.string('language_iso_code');
       table.string('name');
-      table.string('iso_code');
+      table.string('country_iso_code');
     })
     .createTable('cities', function(table) {
       table.increments('id');
-      table.string('country_iso_code');
+      table.string('country_code');
       table.string('name');
     })
     .createTable('admins', function(table) {

--- a/test/integration/helpers/migration.js
+++ b/test/integration/helpers/migration.js
@@ -2,12 +2,12 @@ var _ = require('lodash')
 var Promise = global.testPromise;
 
 var drops = [
-  'sites', 'sitesmeta', 'sites_extra', 'admins',
-  'admins_sites', 'authors', 'authors_posts',
-  'blogs', 'posts', 'tags', 'posts_tags', 'comments',
-  'users', 'roles', 'photos', 'users_roles', 'info',
-  'Customer', 'Settings', 'hostnames', 'instances', 'uuid_test',
-  'parsed_users', 'tokens', 'thumbnails',
+  'sites', 'sitesmeta', 'sites_translations', 'locales',
+  'countries', 'cities', 'admins', 'admins_sites', 'authors',
+  'authors_posts', 'blogs', 'posts', 'tags', 'posts_tags',
+  'comments', 'users', 'roles', 'photos', 'users_roles',
+  'info', 'Customer', 'Settings', 'hostnames', 'instances',
+  'uuid_test', 'parsed_users', 'tokens', 'thumbnails',
   'lefts', 'rights', 'lefts_rights', 'organization'
 ];
 
@@ -34,10 +34,26 @@ module.exports = function(Bookshelf) {
       table.integer('meta_id').notNullable();
       table.text('other_description');
     })
-    .createTable('sites_extra', function(table) {
+    .createTable('sites_translations', function(table) {
       table.increments('id');
       table.string('website_name').notNullable();
-      table.text('extra_description');
+      table.text('translated_content');
+      table.string('locale_iso').notNullable();
+    })
+    .createTable('locales', function(table) {
+      table.increments('id');
+      table.string('iso_code');
+    })
+    .createTable('countries', function(table) {
+      table.increments('id');
+      table.string('language_iso_code');
+      table.string('name');
+      table.string('iso_code');
+    })
+    .createTable('cities', function(table) {
+      table.increments('id');
+      table.string('country_iso_code');
+      table.string('name');
     })
     .createTable('admins', function(table) {
       table.increments('id');

--- a/test/integration/helpers/migration.js
+++ b/test/integration/helpers/migration.js
@@ -2,7 +2,7 @@ var _ = require('lodash')
 var Promise = global.testPromise;
 
 var drops = [
-  'sites', 'sitesmeta', 'admins',
+  'sites', 'sitesmeta', 'sites_extra', 'admins',
   'admins_sites', 'authors', 'authors_posts',
   'blogs', 'posts', 'tags', 'posts_tags', 'comments',
   'users', 'roles', 'photos', 'users_roles', 'info',
@@ -33,6 +33,11 @@ module.exports = function(Bookshelf) {
       table.increments('id');
       table.integer('meta_id').notNullable();
       table.text('other_description');
+    })
+    .createTable('sites_extra', function(table) {
+      table.increments('id');
+      table.string('website_name').notNullable();
+      table.text('extra_description');
     })
     .createTable('admins', function(table) {
       table.increments('id');

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -78,8 +78,12 @@ module.exports = function(Bookshelf) {
     country: function() {
       return this.belongsTo(Country, 'country_code', 'country_iso_code');
     },
-    locales: function() {
-      return this.belongsTo(Locale).through(Country);
+    locale: function() {
+      return this.belongsTo(Locale, 'language_iso_code', 'iso_code').through(Country,
+        'country_code',         // cities.country_code
+        'language_iso_code',    // countries.language_iso_code
+        'country_iso_code',     // countries.country_iso_code
+        'iso_code');            // locales.iso_code
     }
   });
 

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -34,6 +34,16 @@ module.exports = function(Bookshelf) {
     }
   });
 
+  var SiteExtra = Bookshelf.Model.extend({
+    tableName: 'sites_extra',
+    site: function() {
+      return this.belongsTo(Site, 'website_name', 'name');
+    },
+    info: function() {
+      return this.hasOne(Info);
+    }
+  });
+
   var Uuid = Bookshelf.Model.extend({
     idAttribute: 'uuid',
     tableName: 'uuid_test'
@@ -64,6 +74,9 @@ module.exports = function(Bookshelf) {
     },
     info: function() {
       return this.hasOne(Info).through(SiteMeta, 'meta_id');
+    },
+    extra: function() {
+      return this.hasMany(SiteExtra, 'website_name', 'name')
     },
     admins: function() {
       return this.belongsToMany(Admin).withPivot('item');
@@ -354,6 +367,7 @@ module.exports = function(Bookshelf) {
       Site: Site,
       SiteParsed: SiteParsed,
       SiteMeta: SiteMeta,
+      SiteExtra: SiteExtra,
       Admin: Admin,
       Author: Author,
       AuthorParsed: AuthorParsed,

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -65,18 +65,18 @@ module.exports = function(Bookshelf) {
 
   var Country = Bookshelf.Model.extend({
     tableName: 'countries',
-    locales: function() {
+    locale: function() {
       return this.belongsTo(Locale, 'language_iso_code', 'iso_code');
     },
     cities: function() {
-      return this.hasMany(City, 'country_iso_code', 'iso_code');
+      return this.hasMany(City, 'country_code', 'country_iso_code');
     }
   });
 
   var City = Bookshelf.Model.extend({
     tableName: 'cities',
     country: function() {
-      return this.belongsTo(Country, 'country_iso_code', 'iso_code');
+      return this.belongsTo(Country, 'country_code', 'country_iso_code');
     },
     locales: function() {
       return this.belongsTo(Locale).through(Country);

--- a/test/integration/helpers/objects.js
+++ b/test/integration/helpers/objects.js
@@ -34,13 +34,52 @@ module.exports = function(Bookshelf) {
     }
   });
 
-  var SiteExtra = Bookshelf.Model.extend({
-    tableName: 'sites_extra',
+  var SiteTranslation = Bookshelf.Model.extend({
+    tableName: 'sites_translations',
     site: function() {
       return this.belongsTo(Site, 'website_name', 'name');
     },
-    info: function() {
-      return this.hasOne(Info);
+    locale: function() {
+      return this.belongsTo(Locale, 'locale_iso', 'iso_code');
+    }
+  });
+
+  var Locale = Bookshelf.Model.extend({
+    tableName: 'locales',
+    sites: function() {
+      return this.belongsToMany(Site, 'sites_translations', 'locale_iso', 'website_name', 'iso_code', 'name');
+    },
+    countries: function() {
+      return this.hasMany(Country, 'language_iso_code', 'iso_code');
+    },
+    cities: function() {
+      return this.hasMany(City).through(Country);
+    },
+    country: function() {
+      return this.hasOne(Country, 'language_iso_code', 'iso_code');
+    },
+    city: function() {
+      return this.hasOne(City).through(Country);
+    },
+  });
+
+  var Country = Bookshelf.Model.extend({
+    tableName: 'countries',
+    locales: function() {
+      return this.belongsTo(Locale, 'language_iso_code', 'iso_code');
+    },
+    cities: function() {
+      return this.hasMany(City, 'country_iso_code', 'iso_code');
+    }
+  });
+
+  var City = Bookshelf.Model.extend({
+    tableName: 'cities',
+    country: function() {
+      return this.belongsTo(Country, 'country_iso_code', 'iso_code');
+    },
+    locales: function() {
+      return this.belongsTo(Locale).through(Country);
     }
   });
 
@@ -75,8 +114,8 @@ module.exports = function(Bookshelf) {
     info: function() {
       return this.hasOne(Info).through(SiteMeta, 'meta_id');
     },
-    extra: function() {
-      return this.hasMany(SiteExtra, 'website_name', 'name')
+    translation: function() {
+      return this.hasMany(SiteTranslation, 'website_name', 'name')
     },
     admins: function() {
       return this.belongsToMany(Admin).withPivot('item');
@@ -367,7 +406,10 @@ module.exports = function(Bookshelf) {
       Site: Site,
       SiteParsed: SiteParsed,
       SiteMeta: SiteMeta,
-      SiteExtra: SiteExtra,
+      SiteTranslation: SiteTranslation,
+      Locale: Locale,
+      Country: Country,
+      City: City,
       Admin: Admin,
       Author: Author,
       AuthorParsed: AuthorParsed,

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -1871,6 +1871,203 @@ module.exports = {
       }
     }
   },
+  'works with belongsTo (city -> locales)': {
+    mysql: {
+      result: {
+        id: 1,
+        iso_code: 'es',
+        _pivot_country_iso_code: 've',
+        _pivot_language_iso_code: 'es'
+      }
+    },
+    postgresql: {
+      result: {
+        id: 1,
+        iso_code: 'es',
+        _pivot_country_iso_code: 've',
+        _pivot_language_iso_code: 'es'
+      }
+    },
+    sqlite3: {
+      result: {
+        id: 1,
+        iso_code: 'es',
+        _pivot_country_iso_code: 've',
+        _pivot_language_iso_code: 'es'
+      }
+    }
+  },
+  'works with eager loaded belongsTo (city -> locales)': {
+    mysql: {
+      result: {
+        id: 1,
+        country_code: 've',
+        name: 'Caracas',
+        locale: {
+          id: 1,
+          iso_code: 'es',
+          _pivot_country_iso_code: 've',
+          _pivot_language_iso_code: 'es'
+        }
+      }
+    },
+    postgresql: {
+      result: {
+        id: 1,
+        country_code: 've',
+        name: 'Caracas',
+        locale: {
+          id: 1,
+          iso_code: 'es',
+          _pivot_country_iso_code: 've',
+          _pivot_language_iso_code: 'es'
+        }
+      }
+    },
+    sqlite3: {
+      result: {
+        id: 1,
+        country_code: 've',
+        name: 'Caracas',
+        locale: {
+          id: 1,
+          iso_code: 'es',
+          _pivot_country_iso_code: 've',
+          _pivot_language_iso_code: 'es'
+        }
+      }
+    }
+  },
+  'works with hasMany (locale -> cities)': {
+    mysql: {
+      result: [
+        {
+          id: 1,
+          name: 'Caracas',
+          country_code: 've'
+        },
+        {
+          id: 2,
+          name: 'Bogotá',
+          country_code: 'co'
+        },
+        {
+          id: 3,
+          name: 'Medellín',
+          country_code: 'co'
+        }
+      ]
+    },
+    postgresql: {
+      result: [
+        {
+          id: 1,
+          name: 'Caracas',
+          country_code: 've'
+        },
+        {
+          id: 2,
+          name: 'Bogotá',
+          country_code: 'co'
+        },
+        {
+          id: 3,
+          name: 'Medellín',
+          country_code: 'co'
+        }
+      ]
+    },
+    sqlite3: {
+      result: [
+        {
+          id: 1,
+          name: 'Caracas',
+          country_code: 've'
+        },
+        {
+          id: 2,
+          name: 'Bogotá',
+          country_code: 'co'
+        },
+        {
+          id: 3,
+          name: 'Medellín',
+          country_code: 'co'
+        }
+      ]
+    }
+  },
+  'works with eager loaded hasMany (locale -> cities)': {
+    mysql: {
+      result: {
+        id: 1,
+        iso_code: 'es',
+        cities: [
+          {
+            id: 1,
+            name: 'Caracas',
+            country_code: 've'
+          },
+          {
+            id: 2,
+            name: 'Bogotá',
+            country_code: 'co'
+          },
+          {
+            id: 3,
+            name: 'Medellín',
+            country_code: 'co'
+          }
+        ]
+      }
+    },
+    postgresql: {
+      result: {
+        id: 1,
+        iso_code: 'es',
+        cities: [
+          {
+            id: 1,
+            name: 'Caracas',
+            country_code: 've'
+          },
+          {
+            id: 2,
+            name: 'Bogotá',
+            country_code: 'co'
+          },
+          {
+            id: 3,
+            name: 'Medellín',
+            country_code: 'co'
+          }
+        ]
+      }
+    },
+    sqlite3: {
+      result: {
+        id: 1,
+        iso_code: 'es',
+        cities: [
+          {
+            id: 1,
+            name: 'Caracas',
+            country_code: 've'
+          },
+          {
+            id: 2,
+            name: 'Bogotá',
+            country_code: 'co'
+          },
+          {
+            id: 3,
+            name: 'Medellín',
+            country_code: 'co'
+          }
+        ]
+      }
+    }
+  },
   'handles morphOne (photo)': {
     mysql: {
       result: {

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -1626,13 +1626,13 @@ module.exports = {
           id: 1,
           language_iso_code: 'es',
           name: 'Venezuela',
-          iso_code: 've'
+          country_iso_code: 've'
         },
         {
           id: 2,
           language_iso_code: 'es',
           name: 'Colombia',
-          iso_code: 'co'
+          country_iso_code: 'co'
         }
       ]
     },
@@ -1642,13 +1642,13 @@ module.exports = {
           id: 1,
           language_iso_code: 'es',
           name: 'Venezuela',
-          iso_code: 've'
+          country_iso_code: 've'
         },
         {
           id: 2,
           language_iso_code: 'es',
           name: 'Colombia',
-          iso_code: 'co'
+          country_iso_code: 'co'
         }
       ]
     },
@@ -1658,13 +1658,13 @@ module.exports = {
           id: 1,
           language_iso_code: 'es',
           name: 'Venezuela',
-          iso_code: 've'
+          country_iso_code: 've'
         },
         {
           id: 2,
           language_iso_code: 'es',
           name: 'Colombia',
-          iso_code: 'co'
+          country_iso_code: 'co'
         }
       ]
     }
@@ -1679,13 +1679,13 @@ module.exports = {
             id: 1,
             language_iso_code: 'es',
             name: 'Venezuela',
-            iso_code: 've'
+            country_iso_code: 've'
           },
           {
             id: 2,
             language_iso_code: 'es',
             name: 'Colombia',
-            iso_code: 'co'
+            country_iso_code: 'co'
           }
         ]
       }
@@ -1699,13 +1699,13 @@ module.exports = {
             id: 1,
             language_iso_code: 'es',
             name: 'Venezuela',
-            iso_code: 've'
+            country_iso_code: 've'
           },
           {
             id: 2,
             language_iso_code: 'es',
             name: 'Colombia',
-            iso_code: 'co'
+            country_iso_code: 'co'
           }
         ]
       }
@@ -1719,13 +1719,13 @@ module.exports = {
             id: 1,
             language_iso_code: 'es',
             name: 'Venezuela',
-            iso_code: 've'
+            country_iso_code: 've'
           },
           {
             id: 2,
             language_iso_code: 'es',
             name: 'Colombia',
-            iso_code: 'co'
+            country_iso_code: 'co'
           }
         ]
       }
@@ -1737,7 +1737,7 @@ module.exports = {
         id: 3,
         language_iso_code: 'it',
         name: 'Italia',
-        iso_code: 'it'
+        country_iso_code: 'it'
       }
     },
     postgresql: {
@@ -1745,7 +1745,7 @@ module.exports = {
         id: 3,
         language_iso_code: 'it',
         name: 'Italia',
-        iso_code: 'it'
+        country_iso_code: 'it'
       }
     },
     sqlite3: {
@@ -1753,7 +1753,7 @@ module.exports = {
         id: 3,
         language_iso_code: 'it',
         name: 'Italia',
-        iso_code: 'it'
+        country_iso_code: 'it'
       }
     }
   },
@@ -1766,7 +1766,7 @@ module.exports = {
           id: 3,
           language_iso_code: 'it',
           name: 'Italia',
-          iso_code: 'it'
+          country_iso_code: 'it'
         }
       }
     },
@@ -1778,7 +1778,7 @@ module.exports = {
           id: 3,
           language_iso_code: 'it',
           name: 'Italia',
-          iso_code: 'it'
+          country_iso_code: 'it'
         }
       }
     },
@@ -1790,7 +1790,7 @@ module.exports = {
           id: 3,
           language_iso_code: 'it',
           name: 'Italia',
-          iso_code: 'it'
+          country_iso_code: 'it'
         }
       }
     }

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -1561,7 +1561,7 @@ module.exports = {
       }
     }
   },
-  'works with belongsTo otherKey (extra -> site)': {
+  'works with belongsTo (extra -> site)': {
     mysql: {
       result: {
         id: 2,
@@ -1581,11 +1581,12 @@ module.exports = {
       }
     }
   },
-  'works with eager loaded belongsTo otherKey (extra -> site)': {
+  'works with eager loaded belongsTo (extra -> site)': {
     mysql: {
       result: {
         id: 1,
-        extra_description: 'This is the extra description for the Bookshelfjs Site',
+        translated_content: 'Este es el contenido traducido del sitio web de Bookshelfjs',
+        locale_iso: 'es',
         website_name: 'bookshelfjs.org',
         site: {
           id: 2,
@@ -1596,7 +1597,8 @@ module.exports = {
     postgresql: {
       result: {
         id: 1,
-        extra_description: 'This is the extra description for the Bookshelfjs Site',
+        translated_content: 'Este es el contenido traducido del sitio web de Bookshelfjs',
+        locale_iso: 'es',
         website_name: 'bookshelfjs.org',
         site: {
           id: 2,
@@ -1607,12 +1609,265 @@ module.exports = {
     sqlite3: {
       result: {
         id: 1,
-        extra_description: 'This is the extra description for the Bookshelfjs Site',
+        translated_content: 'Este es el contenido traducido del sitio web de Bookshelfjs',
+        locale_iso: 'es',
         website_name: 'bookshelfjs.org',
         site: {
           id: 2,
           name: 'bookshelfjs.org'
         }
+      }
+    }
+  },
+  'works with hasMany (locale -> countries)': {
+    mysql: {
+      result: [
+        {
+          id: 1,
+          language_iso_code: 'es',
+          name: 'Venezuela',
+          iso_code: 've'
+        },
+        {
+          id: 2,
+          language_iso_code: 'es',
+          name: 'Colombia',
+          iso_code: 'co'
+        }
+      ]
+    },
+    postgresql: {
+      result: [
+        {
+          id: 1,
+          language_iso_code: 'es',
+          name: 'Venezuela',
+          iso_code: 've'
+        },
+        {
+          id: 2,
+          language_iso_code: 'es',
+          name: 'Colombia',
+          iso_code: 'co'
+        }
+      ]
+    },
+    sqlite3: {
+      result: [
+        {
+          id: 1,
+          language_iso_code: 'es',
+          name: 'Venezuela',
+          iso_code: 've'
+        },
+        {
+          id: 2,
+          language_iso_code: 'es',
+          name: 'Colombia',
+          iso_code: 'co'
+        }
+      ]
+    }
+  },
+  'works with eager loaded hasMany (locale -> countries)': {
+    mysql: {
+      result: {
+        id: 1,
+        iso_code: 'es',
+        countries: [
+          {
+            id: 1,
+            language_iso_code: 'es',
+            name: 'Venezuela',
+            iso_code: 've'
+          },
+          {
+            id: 2,
+            language_iso_code: 'es',
+            name: 'Colombia',
+            iso_code: 'co'
+          }
+        ]
+      }
+    },
+    postgresql: {
+      result: {
+        id: 1,
+        iso_code: 'es',
+        countries: [
+          {
+            id: 1,
+            language_iso_code: 'es',
+            name: 'Venezuela',
+            iso_code: 've'
+          },
+          {
+            id: 2,
+            language_iso_code: 'es',
+            name: 'Colombia',
+            iso_code: 'co'
+          }
+        ]
+      }
+    },
+    sqlite3: {
+      result: {
+        id: 1,
+        iso_code: 'es',
+        countries: [
+          {
+            id: 1,
+            language_iso_code: 'es',
+            name: 'Venezuela',
+            iso_code: 've'
+          },
+          {
+            id: 2,
+            language_iso_code: 'es',
+            name: 'Colombia',
+            iso_code: 'co'
+          }
+        ]
+      }
+    }
+  },
+  'works with hasOne (locale -> country)': {
+    mysql: {
+      result: {
+        id: 3,
+        language_iso_code: 'it',
+        name: 'Italia',
+        iso_code: 'it'
+      }
+    },
+    postgresql: {
+      result: {
+        id: 3,
+        language_iso_code: 'it',
+        name: 'Italia',
+        iso_code: 'it'
+      }
+    },
+    sqlite3: {
+      result: {
+        id: 3,
+        language_iso_code: 'it',
+        name: 'Italia',
+        iso_code: 'it'
+      }
+    }
+  },
+  'works with eager loaded hasOne (locale -> country)': {
+    mysql: {
+      result: {
+        id: 2,
+        iso_code: 'it',
+        country: {
+          id: 3,
+          language_iso_code: 'it',
+          name: 'Italia',
+          iso_code: 'it'
+        }
+      }
+    },
+    postgresql: {
+      result: {
+        id: 2,
+        iso_code: 'it',
+        country: {
+          id: 3,
+          language_iso_code: 'it',
+          name: 'Italia',
+          iso_code: 'it'
+        }
+      }
+    },
+    sqlite3: {
+      result: {
+        id: 2,
+        iso_code: 'it',
+        country: {
+          id: 3,
+          language_iso_code: 'it',
+          name: 'Italia',
+          iso_code: 'it'
+        }
+      }
+    }
+  },
+  'works with belongsToMany (locale -> sites)': {
+    mysql: {
+      result: [
+        {
+          id: 2,
+          name: 'bookshelfjs.org',
+          _pivot_locale_iso: 'it',
+          _pivot_website_name: 'bookshelfjs.org'
+        }
+      ]
+    },
+    postgresql: {
+      result: [
+        {
+          id: 2,
+          name: 'bookshelfjs.org',
+          _pivot_locale_iso: 'it',
+          _pivot_website_name: 'bookshelfjs.org'
+        }
+      ]
+    },
+    sqlite3: {
+      result: [
+        {
+          id: 2,
+          name: 'bookshelfjs.org',
+          _pivot_locale_iso: 'it',
+          _pivot_website_name: 'bookshelfjs.org'
+        }
+      ]
+    }
+  },
+  'works with eager loaded belongsToMany (locale -> sites)': {
+    mysql: {
+      result: {
+        id: 2,
+        iso_code: 'it',
+        sites: [
+          {
+            id: 2,
+            name: 'bookshelfjs.org',
+            _pivot_locale_iso: 'it',
+            _pivot_website_name: 'bookshelfjs.org'
+          }
+        ]
+      }
+    },
+    postgresql: {
+      result: {
+        id: 2,
+        iso_code: 'it',
+        sites: [
+          {
+            id: 2,
+            name: 'bookshelfjs.org',
+            _pivot_locale_iso: 'it',
+            _pivot_website_name: 'bookshelfjs.org'
+          }
+        ]
+      }
+    },
+    sqlite3: {
+      result: {
+        id: 2,
+        iso_code: 'it',
+        sites: [
+          {
+            id: 2,
+            name: 'bookshelfjs.org',
+            _pivot_locale_iso: 'it',
+            _pivot_website_name: 'bookshelfjs.org'
+          }
+        ]
       }
     }
   },

--- a/test/integration/output/Relations.js
+++ b/test/integration/output/Relations.js
@@ -1561,6 +1561,61 @@ module.exports = {
       }
     }
   },
+  'works with belongsTo otherKey (extra -> site)': {
+    mysql: {
+      result: {
+        id: 2,
+        name: 'bookshelfjs.org'
+      }
+    },
+    postgresql: {
+      result: {
+        id: 2,
+        name: 'bookshelfjs.org'
+      }
+    },
+    sqlite3: {
+      result: {
+        id: 2,
+        name: 'bookshelfjs.org'
+      }
+    }
+  },
+  'works with eager loaded belongsTo otherKey (extra -> site)': {
+    mysql: {
+      result: {
+        id: 1,
+        extra_description: 'This is the extra description for the Bookshelfjs Site',
+        website_name: 'bookshelfjs.org',
+        site: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      }
+    },
+    postgresql: {
+      result: {
+        id: 1,
+        extra_description: 'This is the extra description for the Bookshelfjs Site',
+        website_name: 'bookshelfjs.org',
+        site: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      }
+    },
+    sqlite3: {
+      result: {
+        id: 1,
+        extra_description: 'This is the extra description for the Bookshelfjs Site',
+        website_name: 'bookshelfjs.org',
+        site: {
+          id: 2,
+          name: 'bookshelfjs.org'
+        }
+      }
+    }
+  },
   'handles morphOne (photo)': {
     mysql: {
       result: {

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -21,23 +21,26 @@ module.exports = function(Bookshelf) {
     var Models      = objs.Models;
 
     // Models
-    var Site         = Models.Site;
-    var SiteMeta     = Models.SiteMeta;
-    var SiteExtra    = Models.SiteExtra;
-    var Admin        = Models.Admin;
-    var Author       = Models.Author;
-    var Blog         = Models.Blog;
-    var Post         = Models.Post;
-    var Comment      = Models.Comment;
-    var Tag          = Models.Tag;
-    var User         = Models.User;
-    var Role         = Models.Role;
-    var Thumbnail    = Models.Thumbnail;
-    var Photo        = Models.Photo;
-    var PhotoParsed  = Models.PhotoParsed;
-    var Customer     = Models.Customer;
-    var Instance     = Models.Instance;
-    var Hostname     = Models.Hostname;
+    var Site            = Models.Site;
+    var SiteMeta        = Models.SiteMeta;
+    var SiteTranslation = Models.SiteTranslation;
+    var Locale          = Models.Locale;
+    var Country         = Models.Country;
+    var City            = Models.City;
+    var Admin           = Models.Admin;
+    var Author          = Models.Author;
+    var Blog            = Models.Blog;
+    var Post            = Models.Post;
+    var Comment         = Models.Comment;
+    var Tag             = Models.Tag;
+    var User            = Models.User;
+    var Role            = Models.Role;
+    var Thumbnail       = Models.Thumbnail;
+    var Photo           = Models.Photo;
+    var PhotoParsed     = Models.PhotoParsed;
+    var Customer        = Models.Customer;
+    var Instance        = Models.Instance;
+    var Hostname        = Models.Hostname;
 
     var UserParsed = Models.UserParsed;
     var UserTokenParsed = Models.UserTokenParsed;
@@ -556,20 +559,63 @@ module.exports = function(Bookshelf) {
             .tap(checkTest(this));
         });
 
-        it('works with belongsTo otherKey (extra -> site)', function() {
-          return new SiteExtra({id: 1})
+      });
+
+      describe('Custom targetKey', function() {
+
+        it('works with belongsTo (extra -> site)', function() {
+          return new SiteTranslation({id: 1})
             .fetch()
             .then(function(extra) {
               return extra.site().fetch();
             }).tap(checkTest(this));
         });
 
-        it('works with eager loaded belongsTo otherKey (extra -> site)', function() {
-          return new SiteExtra({id: 1})
+        it('works with eager loaded belongsTo (extra -> site)', function() {
+          return new SiteTranslation({id: 1})
+            .fetch({withRelated: ['site']})
+            .tap(checkTest(this));
+        });
+
+        it('works with hasMany (locale -> countries)', function() {
+          return new Locale({iso_code: 'es'})
             .fetch()
-            .then(function(extra) {
-              return extra.load('site');
-            })
+            .then(function(locale) {
+              return locale.countries().fetch();
+            }).tap(checkTest(this));
+        });
+
+        it('works with eager loaded hasMany (locale -> countries)', function() {
+          return new Locale({iso_code: 'es'})
+            .fetch({withRelated: ['countries']})
+            .tap(checkTest(this));
+        });
+
+        it('works with hasOne (locale -> country)', function() {
+          return new Locale({iso_code: 'it'})
+            .fetch()
+            .then(function(locale) {
+              return locale.country().fetch();
+            }).tap(checkTest(this));
+        });
+
+        it('works with eager loaded hasOne (locale -> country)', function() {
+          return new Locale({iso_code: 'it'})
+            .fetch({withRelated: ['country']})
+            .tap(checkTest(this));
+        });
+
+        it('works with belongsToMany (locale -> sites)', function() {
+          return new Locale({iso_code: 'it'})
+            .fetch()
+            .then(function(locale) {
+              return locale.sites().fetch();
+            }).tap(checkTest(this));
+        });
+
+        it('works with eager loaded belongsToMany (locale -> sites)', function() {
+          return new Locale({iso_code: 'it'})
+            .fetch({withRelated: ['sites']})
             .tap(checkTest(this));
         });
 

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -23,6 +23,7 @@ module.exports = function(Bookshelf) {
     // Models
     var Site         = Models.Site;
     var SiteMeta     = Models.SiteMeta;
+    var SiteExtra    = Models.SiteExtra;
     var Admin        = Models.Admin;
     var Author       = Models.Author;
     var Blog         = Models.Blog;
@@ -552,6 +553,23 @@ module.exports = function(Bookshelf) {
         it('works with eager loaded many-to-many (user -> roles)', function() {
           return new User({uid: 1})
             .fetch({withRelated: ['roles']})
+            .tap(checkTest(this));
+        });
+
+        it('works with belongsTo otherKey (extra -> site)', function() {
+          return new SiteExtra({id: 1})
+            .fetch()
+            .then(function(extra) {
+              return extra.site().fetch();
+            }).tap(checkTest(this));
+        });
+
+        it('works with eager loaded belongsTo otherKey (extra -> site)', function() {
+          return new SiteExtra({id: 1})
+            .fetch()
+            .then(function(extra) {
+              return extra.load('site');
+            })
             .tap(checkTest(this));
         });
 

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -619,6 +619,24 @@ module.exports = function(Bookshelf) {
             .tap(checkTest(this));
         });
 
+        describe('through', function() {
+
+          it('works with belongsTo (city -> locales)', function() {
+            return new City({name: 'Caracas'})
+              .fetch()
+              .then(function(city) {
+                return city.locale().fetch();
+              }).tap(checkTest(this));
+          });
+
+          it('works with eager loaded belongsTo (city -> locales)', function() {
+            return new City({name: 'Caracas'})
+              .fetch({withRelated: ['locale']})
+              .tap(checkTest(this));
+          });
+
+        });
+
       });
 
       describe('Polymorphic associations', function() {


### PR DESCRIPTION
This fixes #1372.

Enables to reference a different attribute of the target model instead of the `idAttribute`.