### PR TITLE
Fix Node 0.10 and 0.12 ESlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-preset-es2015": "^6.0.14",
     "bookshelf-jsdoc-theme": "^0.1.2",
     "chai": "^3.5.0",
-    "eslint": "^3.5.0",
+    "eslint": "2.13.1",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.0",
     "knex": "^0.12.0",


### PR DESCRIPTION
Rollback `eslint` package to version 2.13.1.

**Next release with updated `eslint` should have minor version 11 !**

Closes #1400 
Closes #1399 
Closes #1398