### PR TITLE
Add support for uninstantiated models relations

### DIFF
--- a/src/relation.js
+++ b/src/relation.js
@@ -186,6 +186,10 @@ export default RelationBase.extend({
         return _.result(parent.prototype, 'idAttribute');
 
       case 'parentFk':
+        if (!this.hasParentAttributes()) {
+          return;
+        }
+
         if (this.isThrough()) {
           if (this.type === 'belongsToMany' && this.isThroughForeignKeyTargeted()) {
             return this.parentAttributes[this.throughForeignKeyTarget];
@@ -472,6 +476,9 @@ export default RelationBase.extend({
   },
   isOtherKeyTargeted() {
     return this.otherKeyTarget != null;
+  },
+  hasParentAttributes() {
+    return this.parentAttributes != null;
   },
 
   // Sets the `pivotColumns` to be retrieved along with the current model.

--- a/test/integration/relation.js
+++ b/test/integration/relation.js
@@ -120,6 +120,25 @@ module.exports = function(Bookshelf) {
 
       });
 
+      it('should not error when accessing a relation through an uninstantiated model', function() {
+        var relation = Doctor.prototype.meta();
+        var relatedData = relation.relatedData;
+
+        // Base
+        equal(relatedData.type, 'hasOne');
+        equal(relatedData.target, DoctorMeta);
+        equal(relatedData.targetTableName, 'doctormeta');
+        equal(relatedData.targetIdAttribute, 'customId');
+        equal(relatedData.foreignKey, 'doctoring_id');
+        equal(relatedData.foreignKeyTarget, undefined);
+
+        // Init
+        equal(relatedData.parentId, undefined);
+        equal(relatedData.parentTableName, 'doctors');
+        equal(relatedData.parentIdAttribute, 'id');
+        equal(relatedData.parentFk, undefined);
+      });
+
       it('should handle a hasOne relation', function() {
 
         var base        = new Doctor({id: 1});


### PR DESCRIPTION
This PR adds support for accessing a relation through an uninstantiated model, which is not possible since #1397 because `parentFk` is now retrieved from the parent's attributes instead of its `id` property.

Before this change, getting the relation through uninstantiated models was possible, and although many of its properties were miscalculated with undefined or null values, others were correct and very useful like the relation type, target, etc

A good use case is the [bookshelf-cascade-delete](https://github.com/seegno/bookshelf-cascade-delete) plugin, which calculates the dependency map of an instantiated model, accessing the dependency map of its relations targets (uninstantiated) recursively. 

  