### PR TITLE
✨  trigger creating event for attached models

### DIFF
--- a/src/relation.js
+++ b/src/relation.js
@@ -710,8 +710,10 @@ const pivotHelpers = {
       });
     }
 
-    return builder.insert(data).then(function() {
-      collection.add(item);
+    return this.triggerThen('creating', this, data, options).then(function () {
+      return builder.insert(data).then(function () {
+        collection.add(item);
+      });
     });
   }),
 

--- a/test/integration/relations.js
+++ b/test/integration/relations.js
@@ -281,6 +281,38 @@ module.exports = function(Bookshelf) {
           ]);
         });
 
+        it('attaching event get\'s triggered', function(done){
+          var site1  = new Site({id: 1});
+          var admin1 = new Admin({username: 'syncable', password: 'test'});
+
+          admin1.save().then(function() {
+            site1.related('admins').on('attaching', function(collection, modelToAttach) {
+              expect(collection).to.exist;
+              expect(modelToAttach.get('username')).to.eql(admin1.get('username'));
+              done();
+            });
+
+            return site1.related('admins').attach(admin1);
+          }).catch(done);
+        });
+
+        it('creating event get\'s triggered', function(done){
+          var site1  = new Site({id: 1});
+          var admin1 = new Admin({username: 'syncable', password: 'test'});
+
+          admin1.save().then(function() {
+            site1.related('admins').on('creating', function(collection, data, options) {
+              expect(collection).to.exist;
+              expect(data.site_id).to.exist;
+              expect(data.admin_id).to.exist;
+              expect(options).to.not.exist;
+              done();
+            });
+
+            return site1.related('admins').attach(admin1);
+          }).catch(done);
+        });
+
         it('has an attaching event, which will fail if an error is thrown', function(){
           var site1  = new Site({id: 1});
           var admin1 = new Admin({username: 'syncable', password: 'test'});


### PR DESCRIPTION
closes #1383

- by triggering a `creating` event, everybody is able to extend or change the data to insert
- in our case: attach a custom id
- i've added two test to ensure the events get's triggered and parameters are as expected