### PR TITLE
Use uuid instead of node-uuid (deprecated)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
     "minimist": "^1.1.0",
     "mocha": "^3.0.2",
     "mysql": "^2.5.2",
-    "node-uuid": "~1.4.1",
     "pg": "^6.1.0",
     "semver": "^5.0.3",
     "sinon": "^1.11.1",
     "sinon-chai": "^2.6.0",
-    "sqlite3": "^3.0.5"
+    "sqlite3": "^3.0.5",
+    "uuid": "~3.0.0"
   },
   "peerDependencies": {
     "knex": ">=0.6.10 <0.13.0"

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -1,5 +1,5 @@
 var _    = require('lodash');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var Promise   = global.testPromise;
 


### PR DESCRIPTION
The node-uuid package is deprecated:

```
npm WARN deprecated node-uuid@1.4.7: use uuid module instead
```

This PR replaces node-uuid with uuid.